### PR TITLE
Split model components into their own meshes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+helldivers
+extracted

--- a/app/app.go
+++ b/app/app.go
@@ -71,6 +71,10 @@ var ConfigFormat = ConfigTemplate{
 					Type: ConfigValueEnum,
 					Enum: []string{"highest_detail", "all"},
 				},
+				"components": {
+					Type: ConfigValueEnum,
+					Enum: []string{"combined", "split"},
+				},
 				"image_jpeg": {
 					Type: ConfigValueEnum,
 					Enum: []string{"false", "true"},


### PR DESCRIPTION
This is a feature I wanted when I extracted the Charger model, so I decided to implement it and share with the community.

Model "components" (just what I call them) are various portions of a model that the game uses for a few purposes, most notably the damage states of different body parts of enemies. At least one way of identifying them is via their UV coordinates - it looks like Arrowhead opted to take advantage of repeating texture coordinates to split the UVs for each component, maybe so when an artist was editing the overlapping portions of the model there wouldn't be so many vertices in the way? Whatever the reason, it gives us an easy way to split the components apart, making it easier to get enemies in a specific damage state in Blender.

With this change, I've added a `unit` config option `components` with values `combined` (default) and `split`. When `split` is selected, the model will be split into multiple meshes, one for each unique set of UV integer values. The components will be grouped together with a parent node so that they remain organized when imported.

This is my first time working with Go, so please let me know if I've committed any cardinal sins with these changes.