### PR TITLE
Fix errors associated with incorrect skeleton map parsing

### DIFF
--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -182,7 +182,7 @@ func remapMeshBones(mesh *unit.Mesh, mapping unit.SkeletonMap) {
 	for i := range mesh.BoneIndices {
 		for j := range mesh.BoneIndices[i] {
 			if mesh.BoneWeights[i][j] > 0 {
-				remapIndex := mapping.RemapData.Indices[mesh.BoneIndices[i][j]]
+				remapIndex := mapping.RemapList[0][mesh.BoneIndices[i][j]]
 				mesh.BoneIndices[i][j] = uint8(mapping.BoneIndices[remapIndex])
 			}
 		}


### PR DESCRIPTION
The skeleton maps can have multiple remapping layers which were not being parsed correctly and caused a crash when exporting the skeleton of certain models (exosuit and others for example)

This fixes the crash but doesn't perfectly export the models with multiple remapping layers, some vertices will be associated to the wrong bone - there likely is some data that we need to use to figure out the correct skeleton map and the correct remapping layer for each vertex. It still needs more research, obviously