### PR TITLE
Fix rectangular DDS mipmaps

### DIFF
--- a/dds/dds.go
+++ b/dds/dds.go
@@ -289,9 +289,12 @@ func Decode(r io.Reader, readMipMaps bool) (*DDS, error) {
 	for i := 0; i < info.NumImages; i++ {
 		width, height := int(info.Header.Width), int(info.Header.Height)
 		mipMaps := make([]*DDSMipMap, 0, mipMapsToRead)
-		for j := 0; j < mipMapsToRead; j++ {
-			if width == 0 || height == 0 {
-				break
+		for j := 0; j < mipMapsToRead && j < info.NumMipMaps; j++ {
+			if width == 0 {
+				width = 1
+			}
+			if height == 0 {
+				height = 1
 			}
 
 			var buf []uint8


### PR DESCRIPTION
If a DDS image was rectangular, we would stop reading mipmaps early, causing problems when trying to read multiple layers in a texture array. This fixes the problem my clamping the minimum height and width of a mipmap to 1 so that all mips can be read.

This was causing issues with the skin shader, since their color LUTs use 5 layers with dimensions of 256x16 and 9 mip levels. The height would reach zero after reading the 5th mip level and we would stop reading a layer early due to that.

Before:
![image](https://github.com/user-attachments/assets/c96f006f-af28-4227-ab7d-3370836aff03)

After:
![image](https://github.com/user-attachments/assets/704e9f18-f1d3-4044-bd0d-522a934756a2)
