### PR TITLE
Support reading data from .strings files and exporting multiple triads in one command

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -143,6 +143,15 @@ var ConfigFormat = ConfigTemplate{
 				},
 			},
 		},
+		"strings": {
+			Category: "text",
+			Options: map[string]ConfigTemplateOption{
+				"format": {
+					Type: ConfigValueEnum,
+					Enum: []string{"json", "source"},
+				},
+			},
+		},
 		"raw": {
 			Category: "",
 			Options: map[string]ConfigTemplateOption{
@@ -525,6 +534,12 @@ func (a *App) ExtractFile(ctx context.Context, id stingray.FileID, outDir string
 			extr = extr_texture.ExtractDDS
 		} else {
 			extr = extr_texture.ConvertToPNG
+		}
+	case "strings":
+		if cfg["format"] == "source" {
+			extr = extractor.ExtractFuncRaw(".strings", stingray.DataMain, stingray.DataStream, stingray.DataGPU)
+		} else {
+			extr = extr_strings.ExtractStringsJSON
 		}
 	default:
 		extr = extractor.ExtractFuncRaw("."+typ, stingray.DataMain, stingray.DataStream, stingray.DataGPU)

--- a/app/app.go
+++ b/app/app.go
@@ -232,7 +232,7 @@ type App struct {
 }
 
 // Open game dir and read metadata.
-func OpenGameDir(ctx context.Context, gameDir string, hashes []string, thinhashes []string, triadIDs []stingray.Hash, onProgress func(curr, total int)) (*App, error) {
+func OpenGameDir(ctx context.Context, gameDir string, hashes []string, thinhashes []string, triadIDs []stingray.Hash, armorStrings stingray.Hash, onProgress func(curr, total int)) (*App, error) {
 	dataDir, err := stingray.OpenDataDir(ctx, filepath.Join(gameDir, "data"), onProgress)
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ func OpenGameDir(ctx context.Context, gameDir string, hashes []string, thinhashe
 	}
 
 	stringsFile, ok := dataDir.Files[stingray.FileID{
-		Name: stingray.Hash{Value: 0x7c7587b563f10985},
+		Name: armorStrings,
 		Type: stingray.Sum64([]byte("strings")),
 	}]
 

--- a/cmd/tools/crossref-checker/main.go
+++ b/cmd/tools/crossref-checker/main.go
@@ -97,7 +97,7 @@ func main() {
 
 	ctx := context.Background() // no need to exit cleanly since we're only reading
 	knownHashes := app.ParseHashes(hashes.Hashes)
-	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, []string{}, nil, func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, []string{}, nil, stingray.Hash{}, func(curr, total int) {
 		prt.Statusf("Reading metadata %.0f%%", float64(curr)/float64(total)*100)
 	})
 	if err != nil {

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -26,7 +26,7 @@ type Context interface {
 	Hashes() map[stingray.Hash]string
 	ThinHashes() map[stingray.ThinHash]string
 	// Selected triad ID, if any (-t option).
-	TriadID() *stingray.Hash
+	TriadIDs() []stingray.Hash
 	ArmorSets() map[stingray.Hash]dlbin.ArmorSet
 	// Prints a warning message.
 	Warnf(f string, a ...any)

--- a/extractor/strings/extractor.go
+++ b/extractor/strings/extractor.go
@@ -1,0 +1,36 @@
+package strings
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/xypwn/filediver/extractor"
+	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/stingray/strings"
+)
+
+func ExtractStringsJSON(ctx extractor.Context) error {
+	if !ctx.File().Exists(stingray.DataMain) {
+		return errors.New("no main data")
+	}
+	r, err := ctx.File().Open(ctx.Ctx(), stingray.DataMain)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	strings, err := strings.LoadStingrayStrings(r)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(strings)
+	if err != nil {
+		return nil
+	}
+	out, err := ctx.CreateFile(".json")
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = out.Write(data)
+	return err
+}

--- a/extractor/strings/extractor.go
+++ b/extractor/strings/extractor.go
@@ -22,15 +22,14 @@ func ExtractStringsJSON(ctx extractor.Context) error {
 	if err != nil {
 		return err
 	}
-	data, err := json.Marshal(strings)
-	if err != nil {
-		return nil
-	}
 	out, err := ctx.CreateFile(".json")
 	if err != nil {
 		return err
 	}
 	defer out.Close()
-	_, err = out.Write(data)
+	enc := json.NewEncoder(out)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "    ")
+	err = enc.Encode(strings)
 	return err
 }

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -359,11 +359,13 @@ func ConvertOpts(ctx extractor.Context, imgOpts *extr_material.ImageOptions, glt
 		}
 	}
 	if triadID != nil {
-		armorSet := ctx.ArmorSets()[*triadID]
-		armorSetName = &armorSet.Name
-		if _, contains := armorSet.UnitMetadata[ctx.File().ID().Name]; contains {
-			value := armorSet.UnitMetadata[ctx.File().ID().Name]
-			metadata = &value
+		armorSet, ok := ctx.ArmorSets()[*triadID]
+		if ok {
+			armorSetName = &armorSet.Name
+			if _, contains := armorSet.UnitMetadata[ctx.File().ID().Name]; contains {
+				value := armorSet.UnitMetadata[ctx.File().ID().Name]
+				metadata = &value
+			}
 		}
 	}
 

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -67,7 +67,7 @@ func remapMeshBones(mesh *unit.Mesh, mapping unit.SkeletonMap) error {
 }
 
 // Adds the unit's skeleton to the gltf document
-func addSkeleton(ctx extractor.Context, doc *gltf.Document, unitInfo *unit.Info, boneInfo *bones.BoneInfo) uint32 {
+func addSkeleton(ctx extractor.Context, doc *gltf.Document, unitInfo *unit.Info, boneInfo *bones.BoneInfo, armorName *string) uint32 {
 	var matrices [][4][4]float32 = make([][4][4]float32, len(unitInfo.JointTransformMatrices))
 	gltfConversionMatrix := mgl32.HomogRotate3DX(mgl32.DegToRad(-90.0)).Mul4(mgl32.HomogRotate3DZ(mgl32.DegToRad(0)))
 	for i := range matrices {
@@ -86,11 +86,15 @@ func addSkeleton(ctx extractor.Context, doc *gltf.Document, unitInfo *unit.Info,
 		if node.Extras == nil {
 			continue
 		}
-		extras, ok := node.Extras.(map[string]uint32)
+		extras, ok := node.Extras.(map[string]any)
 		if !ok {
 			continue
 		}
-		skeletonId, ok := extras["skeletonId"]
+		skeletonIdAny, ok := extras["skeletonId"]
+		if !ok {
+			continue
+		}
+		skeletonId, ok := skeletonIdAny.(uint32)
 		if !ok {
 			continue
 		}
@@ -100,6 +104,9 @@ func addSkeleton(ctx extractor.Context, doc *gltf.Document, unitInfo *unit.Info,
 	skeletonId := unitInfo.Bones[2].NameHash.Value
 	var skeletonTag map[string]any = make(map[string]any)
 	skeletonTag["skeletonId"] = skeletonId
+	if armorName != nil {
+		skeletonTag["armorSet"] = *armorName
+	}
 
 	inverseBindMatrices := modeler.WriteAccessor(doc, gltf.TargetNone, matrices)
 	jointIndices := make([]uint32, 0)
@@ -151,25 +158,30 @@ func addSkeleton(ctx extractor.Context, doc *gltf.Document, unitInfo *unit.Info,
 
 	var skeleton *uint32 = nil
 	for skin := range doc.Skins {
-		extras, ok := doc.Skins[skin].Extras.(map[string]uint32)
+		extras, ok := doc.Skins[skin].Extras.(map[string]any)
 		if !ok {
-			extras = make(map[string]uint32)
+			extras = make(map[string]any)
 		}
-		if otherId, contains := extras["skeletonId"]; doc.Skins[skin].Name == ctx.File().ID().Name.String() || (contains && skeletonId == otherId) {
+		otherIdAny, contains := extras["skeletonId"]
+		if otherId, ok := otherIdAny.(uint32); doc.Skins[skin].Name == ctx.File().ID().Name.String() || (contains && ok && skeletonId == otherId) {
 			skeleton = doc.Skins[skin].Skeleton
 			break
 		}
 	}
 
 	if skeleton == nil {
+		idx := len(doc.Nodes)
 		doc.Nodes = append(doc.Nodes, &gltf.Node{
 			Name: ctx.File().ID().Name.String(),
 			Children: []uint32{
 				rootNodeIndex,
 			},
-			Extras: make(map[string]any),
 		})
-		skeleton = gltf.Index(uint32(len(doc.Nodes) - 1))
+		if armorName != nil {
+			extras := map[string]any{"armorSet": *armorName}
+			doc.Nodes[idx].Extras = extras
+		}
+		skeleton = gltf.Index(uint32(idx))
 		doc.Scenes[0].Nodes = append(doc.Scenes[0].Nodes, *skeleton)
 	}
 
@@ -184,7 +196,7 @@ func addSkeleton(ctx extractor.Context, doc *gltf.Document, unitInfo *unit.Info,
 	return uint32(len(doc.Skins) - 1)
 }
 
-func writeMesh(ctx extractor.Context, doc *gltf.Document, componentName string, indices *uint32, positions uint32, normals uint32, texCoords []uint32, material *uint32, joints *uint32, weights *uint32, skin *uint32) uint32 {
+func writeMesh(ctx extractor.Context, doc *gltf.Document, componentName string, indices *uint32, positions uint32, normals uint32, texCoords []uint32, material *uint32, joints *uint32, weights *uint32, skin *uint32, armorSet *string) uint32 {
 	primitive := &gltf.Primitive{
 		Indices: indices,
 		Attributes: map[string]uint32{
@@ -209,15 +221,20 @@ func writeMesh(ctx extractor.Context, doc *gltf.Document, componentName string, 
 			primitive,
 		},
 	})
+	idx := len(doc.Nodes)
 	doc.Nodes = append(doc.Nodes, &gltf.Node{
 		Name: componentName,
 		Mesh: gltf.Index(uint32(len(doc.Meshes) - 1)),
 		Skin: skin,
 	})
-	return uint32(len(doc.Nodes) - 1)
+	if armorSet != nil {
+		extras := map[string]any{"armorSet": *armorSet}
+		doc.Nodes[idx].Extras = extras
+	}
+	return uint32(idx)
 }
 
-func addBoundingBox(doc *gltf.Document, name string, mesh unit.Mesh, info *unit.Info) {
+func addBoundingBox(doc *gltf.Document, name string, mesh unit.Mesh, info *unit.Info, armorSet *string) {
 	var indices []uint32 = []uint32{
 		0, 1,
 		0, 5,
@@ -270,10 +287,15 @@ func addBoundingBox(doc *gltf.Document, name string, mesh unit.Mesh, info *unit.
 			primitive,
 		},
 	})
+	idx := len(doc.Nodes)
 	doc.Nodes = append(doc.Nodes, &gltf.Node{
 		Name: name,
 		Mesh: gltf.Index(uint32(len(doc.Meshes) - 1)),
 	})
+	if armorSet != nil {
+		extras := map[string]any{"armorSet": *armorSet}
+		doc.Nodes[idx].Extras = extras
+	}
 }
 
 func ConvertOpts(ctx extractor.Context, imgOpts *extr_material.ImageOptions, gltfDoc *gltf.Document) error {
@@ -328,7 +350,15 @@ func ConvertOpts(ctx extractor.Context, imgOpts *extr_material.ImageOptions, glt
 	// Get metadata
 	var metadata *dlbin.UnitData = nil
 	var armorSetName *string = nil
-	if triadID := ctx.TriadID(); triadID != nil {
+	var triadID *stingray.Hash = nil
+	for _, triad := range ctx.TriadIDs() {
+		for _, fileTriad := range ctx.File().TriadIDs() {
+			if fileTriad == triad {
+				triadID = &triad
+			}
+		}
+	}
+	if triadID != nil {
 		armorSet := ctx.ArmorSets()[*triadID]
 		armorSetName = &armorSet.Name
 		if _, contains := armorSet.UnitMetadata[ctx.File().ID().Name]; contains {
@@ -397,20 +427,17 @@ func ConvertOpts(ctx extractor.Context, imgOpts *extr_material.ImageOptions, glt
 	var skin *uint32 = nil
 	var parent *uint32 = nil
 	if bonesEnabled && len(unitInfo.Bones) > 2 {
-		skin = gltf.Index(addSkeleton(ctx, doc, unitInfo, boneInfo))
+		skin = gltf.Index(addSkeleton(ctx, doc, unitInfo, boneInfo, armorSetName))
 		parent = doc.Skins[*skin].Skeleton
 	} else {
 		parent = gltf.Index(uint32(len(doc.Nodes)))
 		doc.Nodes = append(doc.Nodes, &gltf.Node{
-			Name:   ctx.File().ID().Name.String(),
-			Extras: make(map[string]any),
+			Name: ctx.File().ID().Name.String(),
 		})
 		doc.Scenes[0].Nodes = append(doc.Scenes[0].Nodes, *parent)
-	}
-
-	if armorSetName != nil {
-		if extras, ok := doc.Nodes[*parent].Extras.(map[string]any); ok {
-			extras["armorSet"] = *armorSetName
+		if armorSetName != nil {
+			extras := map[string]any{"armorSet": *armorSetName}
+			doc.Nodes[*parent].Extras = extras
 		}
 	}
 
@@ -427,7 +454,7 @@ func ConvertOpts(ctx extractor.Context, imgOpts *extr_material.ImageOptions, glt
 		}
 
 		for i, mesh := range meshes {
-			addBoundingBox(doc, fmt.Sprintf("Mesh %d Bounding Box", i), mesh, unitInfo)
+			addBoundingBox(doc, fmt.Sprintf("Mesh %d Bounding Box", i), mesh, unitInfo, armorSetName)
 		}
 	} else {
 		// Load meshes
@@ -568,7 +595,7 @@ func ConvertOpts(ctx extractor.Context, imgOpts *extr_material.ImageOptions, glt
 
 			if ctx.Config()["join_components"] == "true" {
 				indices := gltf.Index(modeler.WriteIndices(doc, mesh.Indices[i]))
-				nodeIdx := writeMesh(ctx, doc, componentName, indices, positions, normals, texCoords, material, joints, weights, skin)
+				nodeIdx := writeMesh(ctx, doc, componentName, indices, positions, normals, texCoords, material, joints, weights, skin, armorSetName)
 
 				doc.Scenes[0].Nodes = append(doc.Scenes[0].Nodes, nodeIdx)
 				if skin == nil {
@@ -608,7 +635,7 @@ func ConvertOpts(ctx extractor.Context, imgOpts *extr_material.ImageOptions, glt
 				componentNum := 0
 				for _, componentIndices := range components {
 					indices := gltf.Index(modeler.WriteIndices(doc, componentIndices))
-					nodeIdx := writeMesh(ctx, doc, fmt.Sprintf("%s cmp %v", componentName, componentNum), indices, positions, normals, texCoords, material, joints, weights, skin)
+					nodeIdx := writeMesh(ctx, doc, fmt.Sprintf("%s cmp %v", componentName, componentNum), indices, positions, normals, texCoords, material, joints, weights, skin, armorSetName)
 
 					doc.Scenes[0].Nodes = append(doc.Scenes[0].Nodes, nodeIdx)
 					if skin == nil {

--- a/patterns/dl_bin.hexpat
+++ b/patterns/dl_bin.hexpat
@@ -193,7 +193,7 @@ struct HelldiverCustomizationKit {
     MurmurHash triad;
     KitType type;
     u32 unk01;
-    u32 offset = (orig & 0xfffff) - 0xa0000;
+    u32 offset = (std::mem::read_unsigned($, 4) & 0xfffff) - 0xa0000;
     $ += 4;
     u32 unk02;
     u32 count;

--- a/patterns/strings.hexpat
+++ b/patterns/strings.hexpat
@@ -1,0 +1,18 @@
+struct String {
+    char data[];
+};
+
+struct Pointer<T> {
+    T *ptr : u32;
+};
+
+struct Strings {
+    u32 magic;
+    u32 version;
+    u32 count;
+    u32 unk;
+    u32 string_ids[count];
+    Pointer<String> strings[count];
+};
+
+Strings strings @ 0x00;

--- a/scripts/dlbin/__init__.py
+++ b/scripts/dlbin/__init__.py
@@ -5,7 +5,7 @@ from enum import IntEnum
 from typing import List, Union, Dict
 
 class Slot(IntEnum):
-    NONE = 0
+    HELMET = 0
     CAPE = 1
     TORSO = 2
     HIPS = 3

--- a/scripts/export_armor_sets.py
+++ b/scripts/export_armor_sets.py
@@ -1,0 +1,36 @@
+from dlbin import DlBin, HelldiverCustomizationKit
+from strings import Strings
+
+from io import BytesIO
+from pathlib import Path
+import json
+
+from argparse import ArgumentParser
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("-strings", "-s", type=Path, help="Path to .strings file to use for mapping armor set names (0x7c7587b563f10985.strings is en_us)")
+    parser.add_argument("armor_sets", type=Path, help="Path to decrypted generated_customization_armor_sets.dl_bin")
+    args = parser.parse_args()
+
+    armor_sets: Path = args.armor_sets
+    strings_path: Path = args.strings
+
+    with armor_sets.open("rb") as f:
+        data = f.read()
+
+    dlbin = DlBin.parse(BytesIO(data))
+
+    json_out = []
+
+    with strings_path.open("rb") as f:
+        strings = Strings.parse(f).mapping
+
+    for item in dlbin.items:
+        content: HelldiverCustomizationKit = item.content
+        json_out.append(content.to_json(strings))
+
+    print(json.dumps(json_out, indent=4))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/openexr/types.py
+++ b/scripts/openexr/types.py
@@ -1,0 +1,473 @@
+import numpy as np
+import struct
+import zlib
+from io import BytesIO
+from enum import IntEnum
+from typing import List, Tuple, Optional
+from typing_extensions import TypedDict
+
+from logging import Logger
+
+logger = Logger("OpenEXR.types")
+
+EXR_MAGIC = 20000630
+
+# Reads a null terminated string, returning all bytes except the null terminator
+def read_cstr(data: BytesIO) -> str:
+    to_return = ""
+    char = data.read(1)
+    while char != b'\0':
+        to_return += char.decode()
+        char = data.read(1)
+    return to_return
+
+class NotAnEXRFileException(ValueError):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+class UnsupportedEXRException(ValueError):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+class PixelType(IntEnum):
+    UINT = 0
+    HALF = 1
+    FLOAT = 2
+
+    def to_numpy(self) -> type:
+        match (self):
+            case (self.UINT):
+                return np.uint32
+            case (self.HALF):
+                return np.float16
+            case (self.FLOAT):
+                return np.float32
+
+    @classmethod
+    def from_numpy(cls, dtype) -> 'PixelType':
+        match(dtype):
+            case (np.uint32):
+                return cls.UINT
+            case (np.float16):
+                return cls.HALF
+            case (np.float32):
+                return cls.FLOAT
+
+class Compression(IntEnum):
+    NONE = 0
+    RLE = 1
+    ZIPS = 2
+    ZIP = 3
+    PIZ = 4
+    PXR24 = 5
+    B44 = 6
+    B44A = 7
+    DWAA = 8
+    DWAB = 9
+
+class LineOrder(IntEnum):
+    INCREASING_Y = 0
+    DECREASING_Y = 1
+    RANDOM_Y = 2
+
+class Box2i:
+    def __init__(self, xMin: int, yMin: int, xMax: int, yMax: int) -> None:
+        self.xMin = xMin
+        self.yMin = yMin
+        self.xMax = xMax
+        self.yMax = yMax
+
+    def serialize(self) -> bytes:
+        return struct.pack("<IIIII", 16, self.xMin, self.yMin, self.xMax, self.yMax)
+
+    @classmethod
+    def deserialize(cls, data: BytesIO) -> 'Box2i':
+        return cls(*(struct.unpack("<IIIII", data.read(20))[1:]))
+
+class Box2f:
+    def __init__(self, xMin: float, yMin: float, xMax: float, yMax: float) -> None:
+        self.xMin = xMin
+        self.yMin = yMin
+        self.xMax = xMax
+        self.yMax = yMax
+
+    def serialize(self) -> bytes:
+        return struct.pack("<Iffff", 16, self.xMin, self.yMin, self.xMax, self.yMax)
+
+    @classmethod
+    def deserialize(cls, data: BytesIO) -> 'Box2f':
+        return cls(*(struct.unpack("<Iffff", data.read(20))[1:]))
+
+class Channel:
+    def __init__(self, name: str, pixeltype: PixelType, pLinear: int, xSampling: int, ySampling: int) -> None:
+        self.name = name
+        self.pixeltype = pixeltype
+        self.pLinear = pLinear
+        self.xSampling = xSampling
+        self.ySampling = ySampling
+
+    def serialize(self) -> bytes:
+        name = self.name.encode()
+        length = len(name)
+        if not name.endswith(b"\0"):
+            length += 1
+        return struct.pack(f"<{length}sIBxxxII", name, int(self.pixeltype), self.pLinear, self.xSampling, self.ySampling)
+
+    @classmethod
+    def deserialize(cls, data: BytesIO) -> 'Channel':
+        name = read_cstr(data)
+        pixeltype = PixelType(struct.unpack("<I", data.read(4))[0])
+        return cls(name, pixeltype, *struct.unpack("<BxxxII", data.read(12)))
+
+class Attributes(TypedDict):
+    channels: List[Channel]
+    compression: Compression
+    dataWindow: Box2i
+    displayWindow: Box2i
+    lineOrder: LineOrder
+    pixelAspectRatio: float
+    screenWindowCenter: Tuple[float, float]
+    screenWindowWidth: float
+
+    @classmethod
+    def serialize(cls, attrs: 'Attributes') -> bytes:
+        data = b""
+        for key, value in attrs.items():
+            if key in Attributes.__annotations__:
+                key_type = Attributes.__annotations__[key]
+                data += struct.pack(f"<{len(key.encode())+1}s", key.encode())
+                if key_type == float:
+                    data += struct.pack("<6sIf", b"float", 4, value)
+                elif key_type == Tuple[float, float]:
+                    data += struct.pack("<4sIff", b"v2f", 8, *value)
+                elif key_type == Compression:
+                    data += struct.pack("<12sIB", b"compression", 1, int(value))
+                elif key_type == LineOrder:
+                    data += struct.pack("<10sIB", b"lineOrder", 1, int(value))
+                elif key_type == Box2f:
+                    data += struct.pack("<6s", b"box2f") + value.serialize()
+                elif key_type == Box2i:
+                    data += struct.pack("<6s", b"box2i") + value.serialize()
+                elif key_type == List[Channel]:
+                    channel_data = b""
+                    for channel in value:
+                        channel_data += channel.serialize()
+                    channel_data += b"\0"
+                    data += struct.pack("<7sI", b"chlist", len(channel_data)) + channel_data
+            else:
+                logger.warning(f"Skipping unknown attribute {key} of type {key_type}")
+
+        data += b"\0"
+        return data
+
+    @classmethod
+    def deserialize(cls, data: BytesIO) -> 'Attributes':
+        attributes = {}
+
+        attr_name = read_cstr(data)
+        while attr_name != "":
+            attr_type = read_cstr(data)
+            attr_size = struct.unpack("<I", data.read(4))[0]
+            attr_data = data.read(attr_size)
+            attr_reader = BytesIO(attr_data)
+            match(attr_name, attr_type):
+                case ("channels", "chlist"):
+                    attributes["channels"] = []
+                    while attr_reader.tell() < attr_size - 1:
+                        attributes["channels"].append(Channel.deserialize(attr_reader))
+                case ("compression", "compression"):
+                    attributes["compression"] = Compression(attr_data[0])
+                case ("dataWindow", "box2i"):
+                    attr_reader = BytesIO(struct.pack("<I", attr_size) + attr_data)
+                    attributes["dataWindow"] = Box2i.deserialize(attr_reader)
+                case ("displayWindow", "box2i"):
+                    attr_reader = BytesIO(struct.pack("<I", attr_size) + attr_data)
+                    attributes["displayWindow"] = Box2i.deserialize(attr_reader)
+                case ("lineOrder", "lineOrder"):
+                    attributes["lineOrder"] = LineOrder(attr_data[0])
+                case ("pixelAspectRatio", "float"):
+                    attributes["pixelAspectRatio"] = struct.unpack("<f", attr_data)[0]
+                case ("screenWindowCenter", "v2f"):
+                    attributes["screenWindowCenter"] = struct.unpack("<2f", attr_data)
+                case ("screenWindowWidth", "float"):
+                    attributes["screenWindowWidth"] = struct.unpack("<f", attr_data)[0]
+                case (_, _):
+                    logger.warning(f"Unknown attribute '{attr_name}' of type '{attr_type}'")
+            attr_name = read_cstr(data)
+        return cls(attributes)
+
+class Scanline:
+    def __init__(self, y_coord: int, data_size: int, pixel_data: bytes, pixels: Optional[np.ndarray] = None):
+        self.y_coord = y_coord
+        self.data_size = data_size
+        self.data = pixel_data
+
+        self.__pixels = pixels
+        self.__adler32 = zlib.adler32(self.data)
+
+    def pixels(self, attrs: Attributes) -> np.ndarray:
+        if self.__pixels is None or self.__adler32 != zlib.crc32(self.data):
+            self.decompress(attrs)
+        return self.__pixels
+
+    def serialize(self) -> bytes:
+        return struct.pack("<II", self.y_coord, self.data_size) + self.data
+
+    @classmethod
+    def __reconstruct(cls, data: bytes) -> bytes:
+        output = [0] * len(data)
+        output[0] = data[0]
+        for i in range(1, len(data)):
+            output[i] = (output[i - 1] + data[i] - 128) & 0xff
+        return bytes(output)
+
+    @classmethod
+    def __interleave(cls, data: bytes) -> bytes:
+        output = [0] * len(data)
+        for i in range(len(data) // 2):
+            output[i * 2] = data[i]
+            output[i * 2 + 1] = data[i + (len(data) + 1) // 2]
+        return bytes(output)
+
+    @classmethod
+    def __serialize_pixels(cls, pixels: np.ndarray) -> bytes:
+        depth = pixels.shape[-1]
+        split = np.dsplit(pixels, pixels.shape[-1])
+        if depth == 4:
+            r, g, b, a = split
+        else:
+            r, g, b = split
+        data = b""
+        for i in range(pixels.shape[0]):
+            if depth == 4:
+                data += a[i].tobytes()
+            data += b[i].tobytes()
+            data += g[i].tobytes()
+            data += r[i].tobytes()
+        return data
+
+    @classmethod
+    def __reorder(cls, data: bytes) -> bytes:
+        output = [0] * len(data)
+        x = 0
+        for i in range(len(data) // 2):
+            output[i] = data[x]
+            output[i + (len(data) + 1) // 2] = data[x+1]
+            x += 2
+        return bytes(output)
+    
+    @classmethod
+    def __deconstruct(cls, data: bytes) -> bytes:
+        output = [0] * len(data)
+        output[0] = data[0]
+        p = data[0]
+        for i in range(1, len(data)):
+            d = (int(data[i]) - p + 0x180) & 0xff
+            p = data[i]
+            output[i] = d
+        return bytes(output)
+
+    def decompress(self, attrs: Attributes) -> None:
+        match(attrs["compression"]):
+            case (Compression.NONE):
+                pixel_data = self.data
+                max_rows = 1
+            case (Compression.ZIP):
+                decompressed = zlib.decompress(self.data)
+                reconstructed = self.__reconstruct(decompressed)
+                pixel_data = self.__interleave(reconstructed)
+                max_rows = 16
+            case (_):
+                raise NotImplementedError(f"{attrs['compression']}")
+        dataWindow: Box2i = attrs["dataWindow"]
+        width = dataWindow.xMax - dataWindow.xMin + 1
+        channelList: List[Channel] = attrs["channels"]
+        rows = []
+        offset = 0
+        last_dtype = None
+        warn_mixed_dtype = True
+        for _ in range(max_rows):
+            channels: List[np.ndarray] = []
+            for channel in channelList:
+                dtype = channel.pixeltype.to_numpy()
+                if last_dtype is not None and last_dtype != dtype and warn_mixed_dtype:
+                    logger.warning("Mixed channel data types might lead to oddities!")
+                    warn_mixed_dtype = False
+                last_dtype = dtype
+                channels.append(np.frombuffer(pixel_data, dtype, width, offset))
+                offset += channels[-1].nbytes
+            rows.append(np.dstack(channels[::-1]))
+            if offset >= len(pixel_data):
+                break
+        self.__pixels = np.vstack(rows)
+
+    def compress(self, attrs: Attributes) -> None:
+        if self.__pixels is None:
+            logger.error("Attempting to compress data that has not been decompressed!")
+            return
+        pixel_data = self.__serialize_pixels(self.__pixels)
+        match(attrs["compression"]):
+            case (Compression.NONE):
+                self.data_size = len(pixel_data)
+                self.data = pixel_data
+            case (Compression.ZIP):
+                reordered = self.__reorder(pixel_data)
+                deconstructed = self.__deconstruct(reordered)
+                compressed = zlib.compress(deconstructed)
+                use_compressed = len(compressed) < len(pixel_data)
+                self.data_size = len(compressed) if use_compressed else len(pixel_data)
+                self.data = compressed if use_compressed else pixel_data
+            case (_):
+                raise NotImplementedError(str(attrs["compression"]))
+
+    def best_compression(self, compare: List[Compression] = [Compression.NONE, Compression.ZIP]) -> Optional[Compression]:
+        if self.__pixels is None:
+            logger.error("No pixels to attempt to compress")
+            return None
+        pixel_data = self.__serialize_pixels(self.__pixels)
+        sizes = [0xFFFFFFFF] * len(compare)
+        for i, method in enumerate(compare):
+            match(method):
+                case (Compression.NONE):
+                    sizes[i] = len(pixel_data)
+                case (Compression.ZIP):
+                    reordered = self.__reorder(pixel_data)
+                    deconstructed = self.__deconstruct(reordered)
+                    compressed = zlib.compress(deconstructed)
+                    sizes[i] = len(compressed)
+                case (_):
+                    continue
+        index = sizes.index(min(sizes))
+        return compare[index]
+
+    @classmethod
+    def deserialize(cls, data: BytesIO) -> 'Scanline':
+        y_coord, data_size = struct.unpack("<II", data.read(8))
+        pixel_data = data.read(data_size)
+        return cls(y_coord, data_size, pixel_data)
+
+    @classmethod
+    def from_pixels(cls, y_coord: int, data: np.ndarray) -> 'Scanline':
+        pixel_data = cls.__serialize_pixels(data)
+        return cls(y_coord, len(pixel_data), pixel_data, pixels=data)
+
+
+class OpenEXR:
+    def __init__(
+            self,
+            magic: int,
+            version: int,
+            attributes: Attributes,
+            offset_table: List[int],
+            scanlines: List[Scanline]
+        ):
+        self.magic = magic
+        self.version = version
+        self.attributes = attributes
+        self.offset_table = offset_table
+        self.scanlines = scanlines
+
+    def serialize(self) -> bytes:
+        data = struct.pack("<IBxxx", self.magic, self.version)
+        data += Attributes.serialize(self.attributes)
+
+        offset_table = []
+
+        offset = len(data) + len(self.scanlines) * 8
+        total_scanline_data = b""
+
+        for scanline in self.scanlines:
+            offset_table.append(offset)
+            data += struct.pack("<Q", offset)
+            scanline_data = scanline.serialize()
+            offset += len(scanline_data)
+            total_scanline_data += scanline_data
+
+        self.offset_table = offset_table
+
+        data += total_scanline_data
+        return data
+    
+    @classmethod
+    def deserialize(cls, data: BytesIO) -> 'OpenEXR':
+        magic, version, flags0, flags1, flags2 = struct.unpack("<IBBBB", data.read(8))
+        if magic != EXR_MAGIC:
+            raise NotAnEXRFileException(f"invalid magic {magic:08x}")
+        if version > 2:
+            raise UnsupportedEXRException(f"unsupported EXR version {version}")
+        if not (flags0 == flags1 == flags2 == 0x0):
+            raise UnsupportedEXRException(f"Uusupported flags in EXR: {flags0:02x}{flags1:02x}{flags2:02x}")
+
+        attributes = Attributes.deserialize(data)
+
+        missing_attributes = []
+        for key in Attributes.__annotations__:
+            if key not in attributes:
+                missing_attributes.append(key)
+        if missing_attributes:
+            join_exp = "\", \""
+            raise UnsupportedEXRException(f"required attributes \"{join_exp.join(missing_attributes)}\" missing")
+
+
+        scanline_count = 0
+        match(attributes["compression"]):
+            case (Compression.NONE):
+                scanline_count = attributes["dataWindow"].yMax - attributes["dataWindow"].yMin + 1
+            case (Compression.ZIP):
+                height = attributes["dataWindow"].yMax - attributes["dataWindow"].yMin + 1
+                scanline_count = height // 16 + (1 if height % 16 != 0 else 0)
+            case (_):
+                raise UnsupportedEXRException(f"compression type {attributes['compression'].name} not supported")
+
+        offset_table = struct.unpack(f"<{scanline_count}Q", data.read(8 * scanline_count))
+        scanlines: List[Scanline] = [Scanline.deserialize(data) for _ in range(scanline_count)]
+
+        return cls(magic, version, attributes, offset_table, scanlines)
+
+    def pixels(self) -> np.ndarray:
+        pixels = []
+        for scanline in self.scanlines:
+            pixels.append(scanline.pixels(self.attributes))
+        return np.vstack(pixels)
+
+    @classmethod
+    def from_pixels(cls, pixels: np.ndarray) -> 'OpenEXR':
+        height, width, channels = pixels.shape
+        if height < 1:
+            raise ValueError("empty pixel array")
+        if channels not in [3, 4]:
+            raise ValueError("only RGB or RGBA channel layouts are supported")
+        channel_names = "ABGR"
+        if channels == 3:
+            channel_names = "BGR"
+        attributes: Attributes = {}
+        attributes["channels"] = [Channel(name, PixelType.from_numpy(pixels.dtype), 0, 1, 1) for name in channel_names]
+        attributes["dataWindow"] = Box2i(0, 0, width - 1, height - 1)
+        attributes["displayWindow"] = Box2i(0, 0, width - 1, height - 1)
+        attributes["lineOrder"] = LineOrder.INCREASING_Y
+        attributes["pixelAspectRatio"] = 1.0
+        attributes["screenWindowCenter"] = (0.0, 0.0)
+        attributes["screenWindowWidth"] = 1.0
+
+        scanline_pixels = np.vsplit(pixels, [16])
+        scanlines: List[Scanline] = []
+        y_coord = 0
+        for line in scanline_pixels:
+            if line.shape[0] == 0:
+                break
+            scanlines.append(Scanline.from_pixels(y_coord, line))
+            y_coord += line.shape[0]
+
+        if height > 1:
+            attributes["compression"] = Compression.ZIP
+        else:
+            compression = scanlines[0].best_compression()
+            attributes["compression"] = compression
+        
+        for scanline in scanlines:
+            scanline.compress(attributes)
+
+        exr = cls(EXR_MAGIC, 2, attributes, [], scanlines)
+        exr.serialize()
+
+        return exr

--- a/scripts/openexr_builder.py
+++ b/scripts/openexr_builder.py
@@ -3,6 +3,8 @@ import numpy as np
 import struct
 from typing import List
 
+from openexr.types import OpenEXR
+
 # Very limited EXR writer - supports files of up to 16 scanlines
 # which must use RGBA float 32 pixels
 #
@@ -12,93 +14,6 @@ from typing import List
 PIXELTYPE_FLOAT = 2
 COMPRESSION_ZIP = 3
 LINEORDER_INC_Y = 0
-
-class Box2i:
-    def __init__(self, xMin: int, yMin: int, xMax: int, yMax: int) -> None:
-        self.xMin = xMin
-        self.yMin = yMin
-        self.xMax = xMax
-        self.yMax = yMax
-
-    def serialize(self) -> bytes:
-        return struct.pack("<IIII", self.xMin, self.yMin, self.xMax, self.yMax)
-
-class Box2f:
-    def __init__(self, xMin: float, yMin: float, xMax: float, yMax: float) -> None:
-        self.xMin = xMin
-        self.yMin = yMin
-        self.xMax = xMax
-        self.yMax = yMax
-
-    def serialize(self) -> bytes:
-        return struct.pack("<ffff", self.xMin, self.yMin, self.xMax, self.yMax)
-
-class ChannelList:
-    def __init__(self, name: str, pixeltype: int, pLinear: int, xSampling: int, ySampling: int) -> None:
-        self.name = name
-        self.pixeltype = pixeltype
-        self.pLinear = pLinear
-        self.xSampling = xSampling
-        self.ySampling = ySampling
-    
-    def serialize(self) -> bytes:
-        return struct.pack("<2sIBxxxII", self.name.encode(), self.pixeltype, self.pLinear, self.xSampling, self.ySampling)
-
-def compress_pixels(pixels: np.ndarray) -> bytes:
-    r, g, b, a = np.dsplit(pixels, pixels.shape[-1])
-    data = b""
-    for i in range(pixels.shape[0]):
-        data += a[i].tobytes()
-        data += b[i].tobytes()
-        data += g[i].tobytes()
-        data += r[i].tobytes()
-    reordered = [0 for _ in range(len(data))]
-    x = 0
-    for i in range(len(data) // 2):
-        reordered[i] = data[x]
-        reordered[i + (len(data) + 1) // 2] = data[x+1]
-        x += 2
-    
-    #mangle
-    p = reordered[0]
-    for i in range(1, len(reordered)):
-        d = (int(reordered[i]) - p + 0x180) & 0xff
-        p = reordered[i]
-        reordered[i] = d
-    
-    return zlib.compress(bytes(reordered))
-
-def make_exr(pixels: np.ndarray) -> bytes:
-    assert pixels.dtype == np.float32
-    height, width, channels = pixels.shape
-    assert channels == 4, "Only RGBA image types supported"
-    assert height <= 16, "Max 16 scanlines supported"
-    # magic, version
-    data = struct.pack("<IBxxx", 20000630, 2)
-    # start attributes
-    data += b"channels\0chlist\0"
-    chlist_data = b""
-    for char in "ABGR":
-        chlist = ChannelList(char, PIXELTYPE_FLOAT, 0, 1, 1)
-        chlist_data += chlist.serialize()
-    chlist_data += b"\0"
-    data += struct.pack("<I", len(chlist_data)) + chlist_data
-    data += b"compression\0compression\0" + struct.pack("<IB", 1, COMPRESSION_ZIP)
-    window = Box2i(0, 0, width - 1, height - 1)
-    data += b"dataWindow\0box2i\0" + struct.pack("<I", 16) + window.serialize()
-    data += b"displayWindow\0box2i\0" + struct.pack("<I", 16) + window.serialize()
-    data += b"lineOrder\0lineOrder\0" + struct.pack("<IB", 1, LINEORDER_INC_Y)
-    data += b"pixelAspectRatio\0float\0" + struct.pack("<If", 4, 1.0)
-    data += b"screenWindowCenter\0v2f\0" + struct.pack("<Iff", 8, 0.0, 0.0)
-    data += b"screenWindowWidth\0float\0" + struct.pack("<If", 4, 1.0)
-    data += b"\0"
-    # start offset table
-    scanlineOffset = len(data) + 8
-    data += struct.pack("<QI", scanlineOffset, 0)
-    compressed = compress_pixels(pixels)
-    data += struct.pack("<I", len(compressed)) + compressed
-    return data
-
 
 def main():
     from argparse import ArgumentParser
@@ -121,7 +36,7 @@ def main():
             try:
                 with file.open("rb") as f:
                     dds = DDS.parse(f)
-                exr = make_exr(dds.pixels().astype(np.float32))
+                exr = OpenEXR.from_pixels(dds.pixels().astype(np.float32)).serialize()
                 exr_path = file.with_suffix(".exr")
                 with exr_path.open("wb") as f:
                     f.write(exr)

--- a/scripts/strings/__init__.py
+++ b/scripts/strings/__init__.py
@@ -1,0 +1,43 @@
+import struct
+from io import BytesIO
+from typing import List, Dict
+
+def read_cstr(data: BytesIO) -> str:
+    to_return = ""
+    char = data.read(1)
+    while char != b"\0" and char != b"":
+        try:
+            to_return += char.decode()
+        except:
+            break
+        char = data.read(1)
+    return to_return
+
+class Strings:
+    def __init__(self, magic: int, version: int, hash_maybe: int, string_ids: List[int], strings: List[str]):
+        self.magic = magic
+        self.version = version
+        self.hash_maybe = hash_maybe
+        self.string_ids = string_ids
+        self.strings = strings
+        self.mapping: Dict[int, str] = {key: val for key, val in zip(string_ids, strings)}
+
+    @classmethod
+    def parse(cls, data: BytesIO):
+        magic, version, count = struct.unpack("<III", data.read(12))
+        if count == 0:
+            return cls(magic, version, 0, [], [])
+        unk = struct.unpack("<I", data.read(4))[0]
+        string_ids = [val[0] for val in struct.iter_unpack("<I", data.read(4 * count))]
+        string_offsets = [val[0] for val in struct.iter_unpack("<I", data.read(4 * count))]
+        strings = []
+        for offset in string_offsets:
+            data.seek(offset)
+            strings.append(read_cstr(data))
+        return cls(magic, version, unk, string_ids, strings)
+
+    def __getitem__(self, key: int):
+        return self.mapping[key]
+    
+    def __contains__(self, key: int):
+        return key in self.mapping

--- a/stingray/dl_bin/dl_bin.go
+++ b/stingray/dl_bin/dl_bin.go
@@ -295,6 +295,7 @@ type UnitData struct {
 }
 
 type ArmorSet struct {
+	Name         string
 	SetId        uint32
 	Passive      CustomizationKitPassive
 	Type         CustomizationKitType
@@ -302,7 +303,7 @@ type ArmorSet struct {
 }
 
 // Map of triad hash to armor set
-func LoadArmorSetDefinitions() (map[stingray.Hash]ArmorSet, error) {
+func LoadArmorSetDefinitions(strings map[uint32]string) (map[stingray.Hash]ArmorSet, error) {
 	file, err := fs.Open("generated_customization_armor_sets.dl_bin")
 	if err != nil {
 		return nil, err
@@ -321,6 +322,14 @@ func LoadArmorSetDefinitions() (map[stingray.Hash]ArmorSet, error) {
 	r, ok := file.(io.ReadSeeker)
 	if !ok {
 		return nil, fmt.Errorf("fs.File does not implement io.ReadSeeker (but it should so this should not happen)")
+	}
+
+	getNameIfContained := func(id uint32) string {
+		if name, contains := strings[id]; contains {
+			return name
+		} else {
+			return fmt.Sprintf("%x", id)
+		}
 	}
 
 	sets := make(map[stingray.Hash]ArmorSet)
@@ -342,6 +351,7 @@ func LoadArmorSetDefinitions() (map[stingray.Hash]ArmorSet, error) {
 		}
 
 		armorSet := ArmorSet{
+			Name:         getNameIfContained(item.Kit.NameCased),
 			SetId:        item.Kit.SetId,
 			Passive:      item.Kit.Passive,
 			Type:         item.Kit.Type,

--- a/stingray/dl_bin/dl_bin.go
+++ b/stingray/dl_bin/dl_bin.go
@@ -15,7 +15,7 @@ var fs embed.FS
 type CustomizationKitSlot uint32
 
 const (
-	SlotUnk           CustomizationKitSlot = 0
+	SlotHelmet        CustomizationKitSlot = 0
 	SlotCape          CustomizationKitSlot = 1
 	SlotTorso         CustomizationKitSlot = 2
 	SlotHips          CustomizationKitSlot = 3
@@ -29,8 +29,8 @@ const (
 
 func (b CustomizationKitSlot) String() string {
 	switch b {
-	case SlotUnk:
-		return "unknown"
+	case SlotHelmet:
+		return "helmet"
 	case SlotCape:
 		return "cape"
 	case SlotTorso:

--- a/stingray/dl_bin/dl_bin.go
+++ b/stingray/dl_bin/dl_bin.go
@@ -151,6 +151,19 @@ const (
 	KitCape   CustomizationKitType = 2
 )
 
+func (v CustomizationKitType) String() string {
+	switch v {
+	case KitArmor:
+		return "Armor"
+	case KitHelmet:
+		return "Helmet"
+	case KitCape:
+		return "Cape"
+	default:
+		return "Unknown"
+	}
+}
+
 type CustomizationKitRarity uint32
 
 const (
@@ -159,6 +172,19 @@ const (
 	RarityUncommon CustomizationKitRarity = 1
 	RarityHeroic   CustomizationKitRarity = 2
 )
+
+func (v CustomizationKitRarity) String() string {
+	switch v {
+	case RarityCommon:
+		return "Common"
+	case RarityUncommon:
+		return "Uncommon"
+	case RarityHeroic:
+		return "Heroic"
+	default:
+		return "Unknown"
+	}
+}
 
 type CustomizationKitPassive uint32
 

--- a/stingray/strings/strings.go
+++ b/stingray/strings/strings.go
@@ -1,0 +1,103 @@
+package strings
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type StingrayStrings struct {
+	Magic   []uint8
+	Version uint32
+	Count   uint32
+	// Not actually sure that this is a signature, but its my best guess as to its purpose
+	Signature *uint32
+	Strings   map[uint32]string
+}
+
+func (s *StingrayStrings) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.Strings)
+}
+
+func ReadCString(r io.Reader) (*string, error) {
+	var data []byte = make([]byte, 1)
+	var toReturn string
+	for {
+		read, err := r.Read(data)
+		if read == 0 {
+			return nil, fmt.Errorf("string read past the end of r")
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		// Break reading string on null terminator
+		if data[0] == 0 {
+			break
+		}
+
+		toReturn = toReturn + string(data)
+	}
+	return &toReturn, nil
+}
+
+func LoadStingrayStrings(r io.ReadSeeker) (*StingrayStrings, error) {
+	magic := make([]uint8, 4)
+	if err := binary.Read(r, binary.LittleEndian, magic); err != nil {
+		return nil, err
+	}
+
+	var version, count, signature uint32
+	if err := binary.Read(r, binary.LittleEndian, &version); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, &count); err != nil {
+		return nil, err
+	}
+
+	if count == 0 {
+		return &StingrayStrings{
+			Magic:     magic,
+			Version:   version,
+			Count:     count,
+			Signature: nil,
+			Strings:   make(map[uint32]string),
+		}, nil
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, &signature); err != nil {
+		return nil, err
+	}
+
+	stringIDs := make([]uint32, count)
+	stringOffsets := make([]uint32, count)
+	strings := make(map[uint32]string)
+
+	if err := binary.Read(r, binary.LittleEndian, stringIDs); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, stringOffsets); err != nil {
+		return nil, err
+	}
+
+	for i, offset := range stringOffsets {
+		r.Seek(int64(offset), io.SeekStart)
+		str, err := ReadCString(r)
+		if err != nil {
+			return nil, err
+		}
+		strings[stringIDs[i]] = *str
+	}
+
+	return &StingrayStrings{
+		Magic:     magic,
+		Version:   version,
+		Count:     count,
+		Signature: &signature,
+		Strings:   strings,
+	}, nil
+}

--- a/stingray/strings/strings.go
+++ b/stingray/strings/strings.go
@@ -1,6 +1,7 @@
 package strings
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -17,7 +18,11 @@ type StingrayStrings struct {
 }
 
 func (s *StingrayStrings) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.Strings)
+	buf := bytes.Buffer{}
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(s.Strings)
+	return buf.Bytes(), err
 }
 
 func ReadCString(r io.Reader) (*string, error) {


### PR DESCRIPTION
This set of changes adds support for reading and exporting strings files.

* .strings can be exported as json
* Armor sets from the armor set customization dl_bin file can have their names filled from any of the .strings files present in the game
* A python script for exporting the armor set dl_bin to json has been added
* The blender exporter python script will now place objects exported from a triad into a collection with the name of their armor set
* Multiple triads may be specified when exporting by providing a comma separated list of IDs. 
  * _This needs a bit more of a rewrite to function perfectly. Ideally we would export each triad "top down", rather than matching files to triads "bottom up." Files that exist in multiple triads will only be exported from a single triad. The goal was to allow matching helmets and armor sets to be exported in a single command_