### PR TITLE
Rework wwise bank/stream extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 __pycache__
 /scripts_dist
 /extracted
+/fd_crossrefs.txt
+/all_files.txt
 cpu.prof

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Extract only video files:
 
 Extract the Super Earth anthem as mp3:
 ```sh
-./filediver -c "audio:format=mp3" -i "content/audio/291227525.wwise_stream"
+./filediver -c "enable:wwise_stream wwise_stream:format=mp3" -i "content/audio/291227525.wwise_stream"
 ```
 
 Extract the DP-00 Tactical armor set:

--- a/patterns/wwise_bank.hexpat
+++ b/patterns/wwise_bank.hexpat
@@ -53,6 +53,8 @@ u32 didxOffset = 0;
 u32 didxSize = 0;
 u32 dataOffset = 0;
 u32 dataSize = 0;
+u32 hircOffset = 0;
+u32 hircSize = 0;
 
 struct Chunk {
     char Type[4];
@@ -65,6 +67,10 @@ struct Chunk {
         ("DATA"): {
             dataOffset = $;
             dataSize = Size;
+        }
+        ("HIRC"): {
+            hircOffset = $;
+            hircSize = Size;
         }
     }
     padding[Size];
@@ -105,3 +111,31 @@ struct DataSection {
 } [[inline]];
 
 DataSection data[didxCount] @ dataOffset /* Location is only for correct viewing order. */;
+
+struct HircObject {
+    u8 Type;
+    u32 Size;
+    u32 ObjectID;
+    match (Type) {
+        (0x02): { // Sound
+            u32 end = $ + Size - 0x4;
+            u32 pluginID;
+            u8 streamType;
+            u32 sourceID;
+            u32 inMemoryMediaSize;
+            u8 sourceBits;
+            $ = end;
+        }
+        (_): {
+            u8 data[Size-0x4];
+        }
+    }
+    
+};
+
+struct HircSection {
+    u32 Count;
+    HircObject objects[Count];
+};
+
+HircSection hirc @ hircOffset;

--- a/stingray/wwise/wwise.go
+++ b/stingray/wwise/wwise.go
@@ -1,0 +1,55 @@
+package wwise
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/util"
+	"github.com/xypwn/filediver/wwise"
+)
+
+type stingrayBnkHeader struct {
+	Unk00 [4]byte
+	Size  uint32
+	Name  stingray.Hash
+}
+
+func OpenRawBnk(in io.ReadSeeker) (io.ReadSeeker, error) {
+	fileSize, err := in.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := in.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	var hdr stingrayBnkHeader
+	if err := binary.Read(in, binary.LittleEndian, &hdr); err != nil {
+		return nil, err
+	}
+	if int64(hdr.Size+0x10) != fileSize {
+		return nil, fmt.Errorf("size specified in header (%v) does not match actual file size (%v)", hdr.Size+0x10, fileSize)
+	}
+
+	return util.NewSectionReadSeeker(
+		in,
+		0x10,
+		fileSize-0x10,
+	)
+}
+
+func OpenBnk(in io.ReadSeeker) (*wwise.Bnk, error) {
+	bnkIn, err := OpenRawBnk(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return wwise.OpenBnk(bnkIn, &wwise.BkhdXorKey{
+		/* https://github.com/Xaymar/Hellextractor/issues/25 */
+		// "reverse-engineer" the key in code:
+		Version: 0x0000008c ^ 0x9211bc20,
+		ID:      0x50c63a23 ^ 0xf3d64a1b,
+	})
+}


### PR DESCRIPTION
Wwise streams are now (almost) all extracted as parts of wwise banks, which is why standalone wwise_stream extraction is now disabled by default.

This also makes it so filediver basically depends on no external audio hashes anymore and can figure out all resource names at initialization (apart from 6 hashes when I was testing).