### PR TITLE
Add multiple ways to extract raw files

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -34,35 +34,79 @@ type Context interface {
 
 type ExtractFunc func(ctx Context) error
 
+func extractByType(ctx Context, typ stingray.DataType, extension string) error {
+	r, err := ctx.File().Open(ctx.Ctx(), typ)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	out, err := ctx.CreateFile(fmt.Sprintf(".%v.%v", extension, typ.Extension()))
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func extractCombined(ctx Context, extension string) error {
+	if !(ctx.File().Exists(stingray.DataMain) || ctx.File().Exists(stingray.DataStream) || ctx.File().Exists(stingray.DataGPU)) {
+		return fmt.Errorf("extractCombined: no data to extract for file")
+	}
+	out, err := ctx.CreateFile(fmt.Sprintf(".%v", extension))
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	for _, typ := range [3]stingray.DataType{stingray.DataMain, stingray.DataStream, stingray.DataGPU} {
+		if !ctx.File().Exists(typ) {
+			continue
+		}
+		r, err := ctx.File().Open(ctx.Ctx(), typ)
+		if err != nil {
+			return err
+		}
+		defer r.Close()
+
+		if _, err := io.Copy(out, r); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func ExtractFuncRaw(extension string) ExtractFunc {
 	return func(ctx Context) error {
-		typeNames := [3]string{"main", "stream", "gpu"}
 		for _, typ := range [3]stingray.DataType{stingray.DataMain, stingray.DataStream, stingray.DataGPU} {
 			if ctx.File().Exists(typ) {
-				if err := func() error {
-					r, err := ctx.File().Open(ctx.Ctx(), typ)
-					if err != nil {
-						return err
-					}
-					defer r.Close()
-
-					out, err := ctx.CreateFile(fmt.Sprintf(".%v.%v", extension, typeNames[typ]))
-					if err != nil {
-						return err
-					}
-					defer out.Close()
-
-					if _, err := io.Copy(out, r); err != nil {
-						return err
-					}
-
-					return nil
-				}(); err != nil {
+				if err := extractByType(ctx, typ, extension); err != nil {
 					return err
 				}
 			}
 		}
 		return nil
+	}
+}
+
+func ExtractFuncRawSingleType(extension string, typ stingray.DataType) ExtractFunc {
+	return func(ctx Context) error {
+		if ctx.File().Exists(typ) {
+			return extractByType(ctx, typ, extension)
+		}
+		return fmt.Errorf("No %v data found", typ.String())
+	}
+}
+
+func ExtractFuncRawCombined(extension string) ExtractFunc {
+	return func(ctx Context) error {
+		return extractCombined(ctx, extension)
 	}
 }
 

--- a/stingray/triad.go
+++ b/stingray/triad.go
@@ -36,6 +36,19 @@ func (t DataType) String() string {
 	}
 }
 
+func (t DataType) Extension() string {
+	switch t {
+	case DataMain:
+		return "main"
+	case DataStream:
+		return "stream"
+	case DataGPU:
+		return "gpu"
+	default:
+		panic("unhandled case")
+	}
+}
+
 type FileID struct {
 	Name Hash
 	Type Hash


### PR DESCRIPTION
This change allows users to export the individual portions of raw files or a fully combined file, in addition to the default of all portions of the files