### PR TITLE
Some unit format and extraction enhancements

### DIFF
--- a/stingray/unit/unit.go
+++ b/stingray/unit/unit.go
@@ -416,12 +416,12 @@ type MeshHeader struct {
 }
 
 type MeshGroup struct {
-	GroupIdx       uint32
-	VertexOffset   uint32
-	NumVertices    uint32
-	IndexOffset    uint32
-	NumIndices     uint32
-	RepeatGroupIdx uint32
+	MaterialIdx  uint32
+	VertexOffset uint32
+	NumVertices  uint32
+	IndexOffset  uint32
+	NumIndices   uint32
+	GroupIdx     uint32
 }
 
 type MeshInfo struct {


### PR DESCRIPTION
I found that what I thought was a strange duplicate group index on the mesh group struct was actually the material index when exporting the Fleshmob - it had several groups that all shared the same material, instead of the typical 1:1 correspondence between group index and material index.
Additionally, when exporting the new crescent overseer with changes introduced by my geometry export overhaul I noticed that the overseers do not actually have LOD0 meshes - the highest detail mesh for their main body is considered LOD1 by the game. I added a special case that will detect when that happens and export the LOD1 mesh instead - it should probably be generalized to export the next lowest LOD instead, but this works for those cases and I'm not sure if there will be a case where LOD2 is the lowest LOD