### PR TITLE
Fix two issues introduced by the addition of material settings

### DIFF
--- a/extractor/material/extractor.go
+++ b/extractor/material/extractor.go
@@ -340,9 +340,13 @@ func compareMaterials(doc *gltf.Document, mat *material.Material, matIdx uint32,
 	}
 	for texUsage := range mat.Textures {
 		usage := TextureUsage(texUsage.Value)
-		extras := doc.Materials[matIdx].Extras.(map[string]uint32)
-		texIdx, contains := extras[usage.String()]
+		extras := doc.Materials[matIdx].Extras.(map[string]interface{})
+		texIdxInterface, contains := extras[usage.String()]
 		if !contains {
+			continue
+		}
+		texIdx, ok := texIdxInterface.(uint32)
+		if !ok {
 			continue
 		}
 		texture := doc.Textures[texIdx]

--- a/scripts/hd2_accurate_blender_importer.py
+++ b/scripts/hd2_accurate_blender_importer.py
@@ -316,6 +316,8 @@ def main():
                 print(f"    Packing textures for material {material['name']}")
                 try:
                     for usage, texIdx in material["extras"].items():
+                        if type(texIdx) != int:
+                            continue
                         textures[usage] = add_texture(gltf, texIdx, usage)
                     for usage in optional_usages:
                         if usage not in textures:


### PR DESCRIPTION
Fixes #64 

Adding the material settings to the exported file caused two problems with the same root cause - since the extras structure was no longer just uint32, go would panic when attempting to cast to uint32 without first casting to interface{}, and the blender importer would try to use some of the settings arrays as texture indices, failing to export in the process.