### PR TITLE
Add patterns that fully parse animation file formats

### DIFF
--- a/patterns/animation.hexpat
+++ b/patterns/animation.hexpat
@@ -1,53 +1,69 @@
 import std.mem;
+import type.float16;
 
-// import stingray; // Not sure where to put custom library files yet =/
-// stingray.hexpat
-import std.io;
 
-using ThinMurmurHash;
-using MurmurHash;
-
-fn formatThinHash(ThinMurmurHash hash) {
-    return std::format("{:08X}", hash.value);
+struct Position {
+    u16 x;
+    u16 y;
+    u16 z;
 };
 
-fn formatHash(MurmurHash hash) {
-    return std::format("{:016X}", hash.value);
+bitfield PackedQuat {
+    first : 10;
+    second : 10;
+    third : 10;
+    largest : 2;
 };
 
-struct ThinMurmurHash {
-    u32 value;
-} [[format("formatThinHash")]];
-
-struct MurmurHash {
-    u64 value;
-} [[format("formatHash")]];
-// end stingray.hexpat
-
-bitfield BoneData {
-    u8 ItemType : 2;
-    u16 BoneId : 10;
-    u32 TimeCode : 20;
-    u48 data : 32;
+bitfield EntryHeader {
+    type : 2;
+    bone : 10;
+    time : 20;
 };
 
-struct AnimationData {
+struct Rotation {
+    PackedQuat data [[inline]];
+};
+
+// Relative to starting scale? Or maybe not float16 but some other format?
+struct Scale {
+    type::float16 x;
+    type::float16 y;
+    type::float16 z;
+};
+
+struct BoneInit {
+    Position pos;
+    Rotation rot;
+    Scale scale;
+};
+
+struct Entry {
+    EntryHeader header;
+    if(header.type == 0) {
+        Rotation data;
+    } else {
+        Position data;
+    }
+};
+
+struct AnimationHeader {
     u32 unk00;
-    u32 channels;
-    float duration;
-    u32 totalSize;
-    BoneData data[10];
-} [[inline]];
-
-s64 offset;
-struct Animation {
-    $ = offset;
-    u32 size;
-    offset = offset - size;
-    $ = offset;
-    AnimationData animData;
-    offset = offset - 4;
+    u32 boneCount;
+    float animationLength;
+    u32 sizeBytes;
+    u32 unk01[2];
+    u16 unk02;
+    u8 varbits[while(std::mem::read_unsigned($, 1) & 0x80 != 0x0)];
+    u8 varbits_end;
+    BoneInit initialTransforms[boneCount];
 };
 
-offset = std::mem::size() - 4;
-Animation animation[while(offset > 0)] @0x00;
+struct Animation {
+    AnimationHeader header;
+    Entry entries[while(std::mem::read_unsigned($, 2) != 0x0003)];
+    u16 end;
+    u32 size;
+};
+
+Animation directions[while(!std::mem::eof())] @0x00;

--- a/patterns/state_machine.hexpat
+++ b/patterns/state_machine.hexpat
@@ -40,12 +40,16 @@ fn relative_to_parent(u128 offset) {
     return addressof(parent.parent);
 };
 
+fn absolute(u128 offset) {
+    return 0;
+};
+
 struct RebasedNullablePtr<T, P, auto base_fn_name> {
     P val = std::mem::read_unsigned($, sizeof(P));
     if(val == 0x0) {
         padding[sizeof(P)];
     } else {
-        T* data : P [[pointer_base(base_fn_name)]];
+        T* data : P [[pointer_base(base_fn_name), inline]];
     }
 };
 
@@ -54,7 +58,7 @@ struct PtrList<T, auto base> {
     RebasedNullablePtr<T, u32, base> ptrs[count];
 };
 
-struct HashList {
+struct AnimationHashList {
     MurmurHash data[parent.parent.hashCount];
 };
 
@@ -116,10 +120,10 @@ struct UnknownVectorList {
 };
 
 struct Animation {
-    MurmurHash path;
+    MurmurHash add_path;
     u32 unk00;
     u32 hashCount;
-    RebasedNullablePtr<HashList, u32, "relative_to_parents_parent"> hashes;
+    RebasedNullablePtr<AnimationHashList, u32, "relative_to_parents_parent"> hashes;
     u32 floatCount;
     RebasedNullablePtr<FloatList, u32, "relative_to_parents_parent"> floats;
     u32 unk01;
@@ -151,15 +155,48 @@ struct AnimationGroup {
     PtrList<Animation, "relative_to_parents_parents_parent"> animations;
 };
 
+struct ThinHashList {
+    ThinMurmurHash items[parent.parent.thinHashCount] [[inline]];
+};
+
+struct ThinHashFloatsList {
+    ThinMurmurHash keys[parent.parent.thinHashFloatsCount];
+    float values[parent.parent.thinHashFloatsCount];
+};
+
+struct UnkFloatArray {
+    u32 count;
+    float unkFloats[count];
+};
+
+struct UnkFLoatArrayList {
+    PtrList<UnkFloatArray, "relative_to_parents_parent"> list;
+};
+
+struct ShortList {
+    u16 items[parent.parent.shortCount];
+};
+
+struct ByteList {
+    u8 items[parent.parent.byteCount];
+};
+
 struct StateMachine {
     u32 unk00;
     u32 count;
     PtrList<AnimationGroup, "relative_to_parents_parent"> *groups : u32;
+    u32 thinHashCount;
+    RebasedNullablePtr<ThinHashList, u32, "absolute"> thinHashes;
+    u32 thinHashFloatsCount;
+    RebasedNullablePtr<ThinHashFloatsList, u32, "absolute"> thinHashFloats;
+    u32 unkIntFloatDataCount;
+    RebasedNullablePtr<UnkFLoatArrayList, u32, "absolute"> unkIntFloatData;
+    u32 unkCount;
+    RebasedNullablePtr<u8, u32, "absolute"> unkData;
+    u32 shortCount;
+    RebasedNullablePtr<ShortList, u32, "absolute"> unkShorts;
+    u32 byteCount;
+    RebasedNullablePtr<ByteList, u32, "absolute"> unkBytes;
 };
-
-u8 *offset1 : u32 @0x10;
-u8 *offset2 : u32 @0x18;
-u8 *offset3 : u32 @0x20;
-u8 *offset4 : u32 @0x28;
 
 StateMachine stateMachine @0x00;


### PR DESCRIPTION
These hex patterns parse the animation files I've seen so far, though some work is still needed to actually translate that to exporting the animations. 

There's a video here by the original designer of BitSquid/Stingray that goes over how the animations work that helped a lot in putting together the patterns, and which should also help with writing the export code: https://www.youtube.com/watch?v=hJzgVZ5wSCk