### PR TITLE
Fix GUI Armor Set export

### DIFF
--- a/cmd/filediver-gui/main.go
+++ b/cmd/filediver-gui/main.go
@@ -910,6 +910,7 @@ func run(onError func(error)) error {
 						extractorConfig,
 						runner,
 						logger,
+						selectedArchives,
 					)
 				}
 				if gameData == nil {


### PR DESCRIPTION
With this change, when someone has selected an archive with an armor set in it, the GUI will now be able to detect which armor set it is and export it the same as the CLI