### PR TITLE
Add strings file hash for the GUI

### DIFF
--- a/cmd/filediver-gui/game_data_manager.go
+++ b/cmd/filediver-gui/game_data_manager.go
@@ -159,7 +159,7 @@ func (gd *GameDataLoad) loadGameData(ctx context.Context) {
 		return
 	}
 
-	a, err := app.OpenGameDir(ctx, gameDir, app.ParseHashes(hashes.Hashes), app.ParseHashes(hashes.ThinHashes), stingray.Hash{}, func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, app.ParseHashes(hashes.Hashes), app.ParseHashes(hashes.ThinHashes), stingray.Hash{Value: 0x7c7587b563f10985}, func(curr, total int) {
 		gd.Lock()
 		gd.Progress = float32(curr+1) / float32(total)
 		gd.Unlock()


### PR DESCRIPTION
The GUI didn't have a default strings file defined, so when armor sets are exported they are not named properly. This hard codes the en-us strings file as the default, though the actual strings system probably deserves some attention since its fairly limited (figuring out the hashes for those files would go a long way I expect)