### PR TITLE
Fonts: add "general punctuation" block

### DIFF
--- a/cmd/filediver-gui/imgui_wrapper/fonts.go
+++ b/cmd/filediver-gui/imgui_wrapper/fonts.go
@@ -11,6 +11,7 @@ import (
 var baseGlyphRanges = [...]imgui.Wchar{
 	0x0020, 0x00ff, // basic latin + supplement
 	0x0100, 0x017f, // latin extended-A
+	0x2000, 0x206f, // general punctuation
 	0x0400, 0x052f, // cyrillic + cyrillic supplement
 	0,
 }


### PR DESCRIPTION
Special quotation marks weren't visible in e.g. 0x18646ded5ccd40c4.strings. This fixes that.