### PR TITLE
Add material preview widget

### DIFF
--- a/cmd/filediver-gui/main.go
+++ b/cmd/filediver-gui/main.go
@@ -255,6 +255,7 @@ func (a *guiApp) onPreDraw(state *imgui_wrapper.State) error {
 		a.previewState, err = previews.NewAutoPreview(
 			a.otoCtx, a.audioSampleRate,
 			a.gameData.Hashes,
+			a.gameData.ThinHashes,
 			func(id stingray.FileID, typ stingray.DataType) (data []byte, exists bool, err error) {
 				file, ok := a.gameData.DataDir.Files[id]
 				if !ok {

--- a/cmd/filediver-gui/main.go
+++ b/cmd/filediver-gui/main.go
@@ -47,6 +47,7 @@ var (
 		stingray.Sum64([]byte("bones")):          "unit bones",
 		stingray.Sum64([]byte("physics")):        "unit physics",
 		stingray.Sum64([]byte("geometry_group")): "group of 3D models",
+		stingray.Sum64([]byte("material")):       "shader settings",
 	}
 	gameFileTypeTooltipsExtra = map[stingray.Hash]string{
 		stingray.Sum64([]byte("wwise_stream")): "All wwise_streams are also contained in a wwise_bank.\nYou probably want to use wwise_bank instead.",
@@ -472,6 +473,7 @@ func (a *guiApp) drawBrowserWindow() {
 							case // previewable and exportable
 								stingray.Sum64([]byte("bik")),
 								stingray.Sum64([]byte("texture")),
+								stingray.Sum64([]byte("material")),
 								stingray.Sum64([]byte("wwise_bank")),
 								stingray.Sum64([]byte("wwise_stream")),
 								stingray.Sum64([]byte("unit")),

--- a/cmd/filediver-gui/widgets/previews/dds_preview.go
+++ b/cmd/filediver-gui/widgets/previews/dds_preview.go
@@ -1,102 +1,11 @@
 package previews
 
 import (
-	"fmt"
-	"image"
-
 	"github.com/AllenDang/cimgui-go/imgui"
 	"github.com/go-gl/gl/v3.2-core/gl"
 	fnt "github.com/xypwn/filediver/cmd/filediver-gui/fonts"
 	"github.com/xypwn/filediver/cmd/filediver-gui/imutils"
-	"github.com/xypwn/filediver/dds"
 )
-
-type DDSPreviewState struct {
-	textureID       uint32
-	imageHasAlpha   bool
-	imageSize       imgui.Vec2
-	ddsInfo         dds.Info
-	offset          imgui.Vec2 // -1 < x,y < 1
-	zoom            float32
-	linearFiltering bool
-	ignoreAlpha     bool
-	err             error
-}
-
-func NewDDSPreview() *DDSPreviewState {
-	pv := &DDSPreviewState{
-		zoom: 1,
-	}
-
-	gl.GenTextures(1, &pv.textureID)
-	gl.BindTexture(gl.TEXTURE_2D, pv.textureID)
-	defer gl.BindTexture(gl.TEXTURE_2D, 0)
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
-	pv.linearFiltering = true
-	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
-
-	return pv
-}
-
-func (pv *DDSPreviewState) Delete() {
-	gl.DeleteTextures(1, &pv.textureID)
-}
-
-func (pv *DDSPreviewState) LoadImage(img *dds.DDS) {
-	pv.err = nil
-
-	gl.BindTexture(gl.TEXTURE_2D, pv.textureID)
-	defer gl.BindTexture(gl.TEXTURE_2D, 0)
-
-	width, height := img.Bounds().Dx(), img.Bounds().Dy()
-	data := make([]uint8, 4*width*height)
-	switch img := img.Image.(type) {
-	case *image.Gray:
-		for i := range width * height {
-			y := img.Pix[i]
-			data[4*i+0] = y
-			data[4*i+1] = y
-			data[4*i+2] = y
-			data[4*i+3] = 255
-		}
-	case *image.Gray16:
-		for i := range width * height {
-			y := img.Pix[2*i]
-			data[4*i+0] = y
-			data[4*i+1] = y
-			data[4*i+2] = y
-			data[4*i+3] = 255
-		}
-	case *image.NRGBA:
-		copy(data, img.Pix)
-	case *image.NRGBA64:
-		for i := range width * height {
-			data[4*i+0] = img.Pix[8*i+0]
-			data[4*i+1] = img.Pix[8*i+2]
-			data[4*i+2] = img.Pix[8*i+4]
-			data[4*i+3] = img.Pix[8*i+6]
-		}
-	default:
-		pv.err = fmt.Errorf("unhandled image type %T", img)
-		return
-	}
-
-	pv.imageHasAlpha = false
-	for i := range width * height {
-		a := data[4*i+3]
-		if a != 255 {
-			pv.imageHasAlpha = true
-			break
-		}
-	}
-
-	pv.imageSize = imgui.NewVec2(float32(width), float32(height))
-	pv.ddsInfo = img.Info
-	gl.BindTexture(gl.TEXTURE_2D, pv.textureID)
-	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, int32(pv.imageSize.X), int32(pv.imageSize.Y), 0, gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(data))
-	gl.BindTexture(gl.TEXTURE_2D, 0)
-}
 
 func DDSPreview(name string, pv *DDSPreviewState) {
 	imgui.PushIDStr(name)
@@ -117,32 +26,7 @@ func DDSPreview(name string, pv *DDSPreviewState) {
 	if imgui.BeginChildStr("##DDS image preview") {
 		pos := imgui.CursorScreenPos()
 		area := imgui.ContentRegionAvail()
-
-		pv.offset.X = min(max(-1, pv.offset.X), 1)
-		pv.offset.Y = min(max(-1, pv.offset.Y), 1)
-
-		scale := pv.zoom
-		{
-			fitXScale, fitYScale := area.X/pv.imageSize.X, area.Y/pv.imageSize.Y
-			scale *= min(fitXScale, fitYScale)
-		}
-
-		scaledImageSize := pv.imageSize.Mul(scale)
-		offsetPx := imgui.NewVec2(pv.offset.X*scaledImageSize.X/2, pv.offset.Y*scaledImageSize.Y/2)
-		imgPos := pos.Sub(scaledImageSize.Div(2)).Add(area.Div(2)).Add(offsetPx)
-		imgui.WindowDrawList().AddImage(imgui.TextureID(pv.textureID), imgPos, imgPos.Add(scaledImageSize))
-		imgui.InvisibleButton("##overlay", area)
-		io := imgui.CurrentIO()
-		if imgui.IsItemActive() {
-			md := io.MouseDelta()
-			md.X /= scaledImageSize.X / 2
-			md.Y /= scaledImageSize.Y / 2
-			pv.offset = pv.offset.Add(md)
-		}
-		if imgui.IsItemHovered() {
-			scroll := io.MouseWheel()
-			pv.zoom = min(max(0.9, pv.zoom+(0.1*pv.zoom*scroll)), 1000)
-		}
+		BuildImagePreviewArea(pv, pos, area)
 	}
 	imgui.EndChild()
 

--- a/cmd/filediver-gui/widgets/previews/material_preview.go
+++ b/cmd/filediver-gui/widgets/previews/material_preview.go
@@ -103,9 +103,15 @@ func (pv *MaterialPreviewState) LoadMaterial(mat *material.Material, getResource
 		}
 	}
 
+	unknownUsage := extr_material.SettingsUsage(0x0)
+	unknownUsageStr := unknownUsage.String()
+
 	for key, value := range mat.Settings {
 		usage := extr_material.SettingsUsage(key.Value)
 		keyName := usage.String()
+		if keyName == unknownUsageStr {
+			keyName += " (" + key.String() + ")"
+		}
 		pv.settings[keyName] = value
 		pv.settingKeys = append(pv.settingKeys, keyName)
 	}
@@ -237,15 +243,7 @@ func MaterialPreview(name string, pv *MaterialPreviewState) {
 				imgui.TextUnformatted(id)
 
 				imgui.TableNextColumn()
-				var color imgui.Vec4 = imgui.NewVec4(1, 1, 1, 1)
 				settingValue := pv.settings[id]
-				// switch len(settingValue) {
-				// case 3, 4:
-				// 	color.X = settingValue[0]
-				// 	color.Y = settingValue[1]
-				// 	color.Z = settingValue[2]
-				// 	fallthrough
-				// default:
 				formatted := make([]string, len(settingValue))
 				for i := range settingValue {
 					formatted[i] = fmt.Sprintf("%.3f", settingValue[i])
@@ -254,10 +252,7 @@ func MaterialPreview(name string, pv *MaterialPreviewState) {
 				if len(settingValue) > 1 {
 					settingString = "(" + settingString + ")"
 				}
-				imgui.PushStyleColorVec4(imgui.ColText, color)
 				imgui.Text(settingString)
-				imgui.PopStyleColor()
-				//}
 				imgui.PopID()
 			}
 		}

--- a/cmd/filediver-gui/widgets/previews/material_preview.go
+++ b/cmd/filediver-gui/widgets/previews/material_preview.go
@@ -1,0 +1,263 @@
+package previews
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/AllenDang/cimgui-go/imgui"
+	"github.com/go-gl/gl/v3.2-core/gl"
+	fnt "github.com/xypwn/filediver/cmd/filediver-gui/fonts"
+	"github.com/xypwn/filediver/cmd/filediver-gui/imutils"
+	"github.com/xypwn/filediver/dds"
+	extr_material "github.com/xypwn/filediver/extractor/material"
+	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/stingray/unit/material"
+	"github.com/xypwn/filediver/stingray/unit/texture"
+)
+
+type MaterialPreviewState struct {
+	textures      map[string]*DDSPreviewState
+	textureKeys   [][2]string
+	activeTexture int
+	settings      map[string][]float32
+	settingKeys   []string
+
+	offset          imgui.Vec2
+	zoom            float32
+	linearFiltering bool
+	err             error
+}
+
+func NewMaterialPreview() *MaterialPreviewState {
+	return &MaterialPreviewState{
+		textures:      make(map[string]*DDSPreviewState),
+		textureKeys:   make([][2]string, 0),
+		activeTexture: -1,
+		settings:      make(map[string][]float32),
+	}
+}
+
+func (pv *MaterialPreviewState) Delete() {
+	for key := range pv.textures {
+		pv.textures[key].Delete()
+	}
+}
+
+func (pv *MaterialPreviewState) LoadMaterial(mat *material.Material, getResource GetResourceFunc, hashes map[stingray.Hash]string, thinhashes map[stingray.ThinHash]string) error {
+	if mat == nil {
+		return fmt.Errorf("attempted to load nil material")
+	}
+	if len(pv.textures) > 0 {
+		pv.Delete()
+		pv.textures = make(map[string]*DDSPreviewState)
+		pv.textureKeys = make([][2]string, 0)
+		pv.activeTexture = -1
+	}
+	if len(pv.settings) > 0 {
+		pv.settingKeys = make([]string, 0)
+		pv.settings = make(map[string][]float32)
+	}
+	for key, path := range mat.Textures {
+		var imageName, pathName string
+		var ok bool
+		usage := extr_material.TextureUsage(key.Value)
+		imageName = usage.String()
+		if pathName, ok = hashes[path]; !ok {
+			pathName = path.String()
+		}
+		dataMain, _, err := getResource(stingray.FileID{Name: path, Type: stingray.Sum64([]byte("texture"))}, stingray.DataMain)
+		if err != nil {
+			return fmt.Errorf("material texture %v: loading main data: %w", pathName, err)
+		}
+
+		dataGPU, _, err := getResource(stingray.FileID{Name: path, Type: stingray.Sum64([]byte("texture"))}, stingray.DataGPU)
+		if err != nil {
+			return fmt.Errorf("material texture %v: loading gpu data: %w", pathName, err)
+		}
+
+		dataStream, _, err := getResource(stingray.FileID{Name: path, Type: stingray.Sum64([]byte("texture"))}, stingray.DataStream)
+		if err != nil {
+			dataStream = make([]byte, 0)
+		}
+
+		r := io.MultiReader(
+			bytes.NewReader(dataMain),
+			bytes.NewReader(dataStream),
+			bytes.NewReader(dataGPU),
+		)
+		if _, err := texture.DecodeInfo(r); err != nil {
+			return fmt.Errorf("material texture %v: loading stingray DDS info: %w", pathName, err)
+		}
+		img, err := dds.Decode(r, false)
+		if err != nil {
+			return fmt.Errorf("material texture %v: loading DDS image: %w", pathName, err)
+		}
+
+		pv.textureKeys = append(pv.textureKeys, [2]string{imageName, pathName})
+		pv.textures[imageName] = NewDDSPreview()
+		pv.textures[imageName].LoadImage(img)
+		if pv.activeTexture == -1 {
+			pv.activeTexture = 0
+		}
+	}
+
+	for key, value := range mat.Settings {
+		usage := extr_material.SettingsUsage(key.Value)
+		keyName := usage.String()
+		pv.settings[keyName] = value
+		pv.settingKeys = append(pv.settingKeys, keyName)
+	}
+
+	return nil
+}
+
+func MaterialPreview(name string, pv *MaterialPreviewState) {
+	imgui.PushIDStr(name)
+	defer imgui.PopID()
+
+	if pv.err != nil {
+		imutils.TextError(pv.err)
+		return
+	}
+
+	var ddsPv *DDSPreviewState
+	var textureUsage, texturePath string
+	if pv.activeTexture >= 0 && pv.activeTexture < len(pv.textureKeys) {
+		textureUsage = pv.textureKeys[pv.activeTexture][0]
+		texturePath = pv.textureKeys[pv.activeTexture][1]
+		ddsPv = pv.textures[textureUsage]
+	}
+	if ddsPv != nil {
+		imutils.Textf("Usage=%v (%v/%v)\nSize=(%v,%v)\nFormat=%v\nPath=%v\nNum Settings=%v", textureUsage, pv.activeTexture+1, len(pv.textures), ddsPv.imageSize.X, ddsPv.imageSize.Y, ddsPv.ddsInfo.DXT10Header.DXGIFormat, texturePath, len(pv.settings))
+		ddsPv.offset = pv.offset
+		ddsPv.zoom = pv.zoom
+	} else {
+		imutils.Textf("Usage=N/A (0/0)\nSize=N/A\nFormat=N/A\nPath=N/A\nNum Settings=%v", len(pv.settings))
+	}
+
+	{
+		size := imgui.ContentRegionAvail()
+		size.Y -= imutils.ComboHeight()
+		if len(pv.settings) > 0 {
+			size.Y -= imgui.TextLineHeightWithSpacing() * float32(min(len(pv.settings)+2, 6))
+		}
+		imgui.SetNextWindowSize(size)
+	}
+
+	if imgui.BeginChildStr("##DDS image preview") {
+		pos := imgui.CursorScreenPos()
+		area := imgui.ContentRegionAvail()
+		BuildImagePreviewArea(ddsPv, pos, area)
+		// Image Preview Area can modify the image's offset/zoom, but we'd like those to be applied
+		// for the entire material, so copy them out
+		if ddsPv != nil {
+			pv.offset = ddsPv.offset
+			pv.zoom = ddsPv.zoom
+		}
+		style := imgui.CurrentStyle()
+		imgui.SetCursorScreenPos(imgui.NewVec2(pos.X+style.ItemSpacing().X, pos.Y+area.Y/2))
+		imgui.BeginDisabledV(len(pv.textureKeys) < 2)
+		if imgui.Button(fnt.I("Arrow_left")) {
+			pv.activeTexture = pv.activeTexture - 1
+			if pv.activeTexture < 0 {
+				pv.activeTexture = len(pv.textureKeys) - 1
+			}
+		}
+		imgui.EndDisabled()
+		imgui.SetCursorScreenPos(imgui.NewVec2(pos.X+area.X-imgui.FrameHeightWithSpacing()-style.ItemSpacing().X, pos.Y+area.Y/2))
+		imgui.BeginDisabledV(len(pv.textureKeys) < 2)
+		if imgui.Button(fnt.I("Arrow_right")) {
+			pv.activeTexture = pv.activeTexture + 1
+			if pv.activeTexture >= len(pv.textureKeys) {
+				pv.activeTexture = 0
+			}
+		}
+		imgui.EndDisabled()
+	}
+	imgui.EndChild()
+
+	if imgui.Button(fnt.I("Home")) {
+		pv.offset = imgui.NewVec2(0, 0)
+		pv.zoom = 1
+	}
+	imgui.SetItemTooltip("Reset view")
+	imgui.SameLine()
+	imgui.BeginDisabledV(ddsPv == nil)
+	if imgui.Checkbox("Linear filtering", &pv.linearFiltering) {
+		filter := int32(gl.NEAREST)
+		if pv.linearFiltering {
+			filter = gl.LINEAR
+		}
+		gl.BindTexture(gl.TEXTURE_2D, ddsPv.textureID)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter)
+		gl.BindTexture(gl.TEXTURE_2D, 0)
+	}
+	imgui.EndDisabled()
+	imgui.SetItemTooltip("Linear filtering \"blurs\" pixels when zooming in. Disable to view individual pixels more clearly.")
+	imgui.SameLine()
+	imgui.BeginDisabledV(ddsPv == nil || !ddsPv.imageHasAlpha)
+	var ignoreAlphaProxy bool
+	if imgui.Checkbox("Ignore alpha", &ignoreAlphaProxy) && ddsPv != nil {
+		ddsPv.ignoreAlpha = ignoreAlphaProxy
+		swizzleA := int32(gl.ALPHA)
+		if ddsPv.ignoreAlpha {
+			swizzleA = gl.ONE
+		}
+		gl.BindTexture(gl.TEXTURE_2D, ddsPv.textureID)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_SWIZZLE_A, swizzleA)
+		gl.BindTexture(gl.TEXTURE_2D, 0)
+	}
+	imgui.EndDisabled()
+	if ddsPv == nil || !ddsPv.imageHasAlpha {
+		imgui.SetItemTooltip("This image doesn't use an alpha component.")
+	} else {
+		imgui.SetItemTooltip("Ignore alpha component, making RGB components always fully visible.")
+	}
+
+	const tableFlags = imgui.TableFlagsResizable | imgui.TableFlagsBorders | imgui.TableFlagsScrollY | imgui.TableFlagsRowBg
+	if len(pv.settings) > 0 && imgui.BeginTableV("##Material Settings", 2, tableFlags, imgui.NewVec2(0, 0), 0) {
+		imgui.TableSetupColumnV("Name", imgui.TableColumnFlagsWidthStretch, 1, 0)
+		imgui.TableSetupColumnV("Value", imgui.TableColumnFlagsWidthStretch, 2, 0)
+		imgui.TableSetupScrollFreeze(0, 1)
+		imgui.TableHeadersRow()
+
+		clipper := imgui.NewListClipper()
+		clipper.Begin(int32(len(pv.settingKeys)))
+		for clipper.Step() {
+			for row := clipper.DisplayStart(); row < clipper.DisplayEnd(); row++ {
+				id := pv.settingKeys[row]
+				imgui.PushIDStr(id)
+
+				imgui.TableNextColumn()
+				imgui.TextUnformatted(id)
+
+				imgui.TableNextColumn()
+				var color imgui.Vec4 = imgui.NewVec4(1, 1, 1, 1)
+				settingValue := pv.settings[id]
+				// switch len(settingValue) {
+				// case 3, 4:
+				// 	color.X = settingValue[0]
+				// 	color.Y = settingValue[1]
+				// 	color.Z = settingValue[2]
+				// 	fallthrough
+				// default:
+				formatted := make([]string, len(settingValue))
+				for i := range settingValue {
+					formatted[i] = fmt.Sprintf("%.3f", settingValue[i])
+				}
+				settingString := strings.Join(formatted, ", ")
+				if len(settingValue) > 1 {
+					settingString = "(" + settingString + ")"
+				}
+				imgui.PushStyleColorVec4(imgui.ColText, color)
+				imgui.Text(settingString)
+				imgui.PopStyleColor()
+				//}
+				imgui.PopID()
+			}
+		}
+		imgui.EndTable()
+	}
+}

--- a/cmd/filediver-gui/widgets/previews/material_preview.go
+++ b/cmd/filediver-gui/widgets/previews/material_preview.go
@@ -199,6 +199,9 @@ func MaterialPreview(name string, pv *MaterialPreviewState) {
 	imgui.SameLine()
 	imgui.BeginDisabledV(ddsPv == nil || !ddsPv.imageHasAlpha)
 	var ignoreAlphaProxy bool
+	if ddsPv != nil {
+		ignoreAlphaProxy = ddsPv.ignoreAlpha
+	}
 	if imgui.Checkbox("Ignore alpha", &ignoreAlphaProxy) && ddsPv != nil {
 		ddsPv.ignoreAlpha = ignoreAlphaProxy
 		swizzleA := int32(gl.ALPHA)

--- a/cmd/filediver-gui/widgets/previews/preview_common.go
+++ b/cmd/filediver-gui/widgets/previews/preview_common.go
@@ -1,5 +1,131 @@
 package previews
 
-import "github.com/xypwn/filediver/stingray"
+import (
+	"fmt"
+	"image"
+
+	"github.com/AllenDang/cimgui-go/imgui"
+	"github.com/go-gl/gl/v3.2-core/gl"
+	"github.com/xypwn/filediver/dds"
+	"github.com/xypwn/filediver/stingray"
+)
 
 type GetResourceFunc func(id stingray.FileID, typ stingray.DataType) (data []byte, exists bool, err error)
+
+type DDSPreviewState struct {
+	textureID       uint32
+	imageHasAlpha   bool
+	imageSize       imgui.Vec2
+	ddsInfo         dds.Info
+	offset          imgui.Vec2 // -1 < x,y < 1
+	zoom            float32
+	linearFiltering bool
+	ignoreAlpha     bool
+	err             error
+}
+
+func NewDDSPreview() *DDSPreviewState {
+	pv := &DDSPreviewState{
+		zoom: 1,
+	}
+
+	gl.GenTextures(1, &pv.textureID)
+	gl.BindTexture(gl.TEXTURE_2D, pv.textureID)
+	defer gl.BindTexture(gl.TEXTURE_2D, 0)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+	pv.linearFiltering = true
+	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
+
+	return pv
+}
+
+func (pv *DDSPreviewState) Delete() {
+	gl.DeleteTextures(1, &pv.textureID)
+}
+
+func (pv *DDSPreviewState) LoadImage(img *dds.DDS) {
+	pv.err = nil
+
+	gl.BindTexture(gl.TEXTURE_2D, pv.textureID)
+	defer gl.BindTexture(gl.TEXTURE_2D, 0)
+
+	width, height := img.Bounds().Dx(), img.Bounds().Dy()
+	data := make([]uint8, 4*width*height)
+	switch img := img.Image.(type) {
+	case *image.Gray:
+		for i := range width * height {
+			y := img.Pix[i]
+			data[4*i+0] = y
+			data[4*i+1] = y
+			data[4*i+2] = y
+			data[4*i+3] = 255
+		}
+	case *image.Gray16:
+		for i := range width * height {
+			y := img.Pix[2*i]
+			data[4*i+0] = y
+			data[4*i+1] = y
+			data[4*i+2] = y
+			data[4*i+3] = 255
+		}
+	case *image.NRGBA:
+		copy(data, img.Pix)
+	case *image.NRGBA64:
+		for i := range width * height {
+			data[4*i+0] = img.Pix[8*i+0]
+			data[4*i+1] = img.Pix[8*i+2]
+			data[4*i+2] = img.Pix[8*i+4]
+			data[4*i+3] = img.Pix[8*i+6]
+		}
+	default:
+		pv.err = fmt.Errorf("unhandled image type %T", img)
+		return
+	}
+
+	pv.imageHasAlpha = false
+	for i := range width * height {
+		a := data[4*i+3]
+		if a != 255 {
+			pv.imageHasAlpha = true
+			break
+		}
+	}
+
+	pv.imageSize = imgui.NewVec2(float32(width), float32(height))
+	pv.ddsInfo = img.Info
+	gl.BindTexture(gl.TEXTURE_2D, pv.textureID)
+	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, int32(pv.imageSize.X), int32(pv.imageSize.Y), 0, gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(data))
+	gl.BindTexture(gl.TEXTURE_2D, 0)
+}
+
+func BuildImagePreviewArea(pv *DDSPreviewState, pos, area imgui.Vec2) {
+	scaledImageSize := imgui.NewVec2(0, 0)
+	if pv != nil {
+		pv.offset.X = min(max(-1, pv.offset.X), 1)
+		pv.offset.Y = min(max(-1, pv.offset.Y), 1)
+
+		scale := pv.zoom
+		{
+			fitXScale, fitYScale := area.X/pv.imageSize.X, area.Y/pv.imageSize.Y
+			scale *= min(fitXScale, fitYScale)
+		}
+
+		scaledImageSize = pv.imageSize.Mul(scale)
+		offsetPx := imgui.NewVec2(pv.offset.X*scaledImageSize.X/2, pv.offset.Y*scaledImageSize.Y/2)
+		imgPos := pos.Sub(scaledImageSize.Div(2)).Add(area.Div(2)).Add(offsetPx)
+		imgui.WindowDrawList().AddImage(imgui.TextureID(pv.textureID), imgPos, imgPos.Add(scaledImageSize))
+	}
+	imgui.InvisibleButton("##overlay", area)
+	io := imgui.CurrentIO()
+	if imgui.IsItemActive() && pv != nil {
+		md := io.MouseDelta()
+		md.X /= scaledImageSize.X / 2
+		md.Y /= scaledImageSize.Y / 2
+		pv.offset = pv.offset.Add(md)
+	}
+	if imgui.IsItemHovered() && pv != nil {
+		scroll := io.MouseWheel()
+		pv.zoom = min(max(0.9, pv.zoom+(0.1*pv.zoom*scroll)), 1000)
+	}
+}

--- a/cmd/filediver-gui/widgets/previews/preview_common.go
+++ b/cmd/filediver-gui/widgets/previews/preview_common.go
@@ -116,6 +116,7 @@ func BuildImagePreviewArea(pv *DDSPreviewState, pos, area imgui.Vec2) {
 		imgPos := pos.Sub(scaledImageSize.Div(2)).Add(area.Div(2)).Add(offsetPx)
 		imgui.WindowDrawList().AddImage(imgui.TextureID(pv.textureID), imgPos, imgPos.Add(scaledImageSize))
 	}
+	imgui.SetNextItemAllowOverlap()
 	imgui.InvisibleButton("##overlay", area)
 	io := imgui.CurrentIO()
 	if imgui.IsItemActive() && pv != nil {

--- a/dds/dds.go
+++ b/dds/dds.go
@@ -320,7 +320,7 @@ func Decode(r io.Reader, readMipMaps bool) (*DDS, error) {
 				return nil, errors.New("invalid color model passed by info structure")
 			}
 			if err := info.Decompress(buf, r, width, height, info); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("decode image %v mip %v: %w", i, j, err)
 			}
 			mipMaps = append(mipMaps, &DDSMipMap{
 				Image:  img,


### PR DESCRIPTION
Adds a preview for the material file format which includes the images they reference and the settings in the file.

Some improvements I can immediately see:
1. Settings should likely be reactive to space available, so if the user maximises the window they turn into a sidebar, while if the width available is less than a certain threshold they stack at the bottom
2. Maybe once we've done more research regarding HLSLcc/integrated it into the project, we could use it to create preview models with the material applied - this would require a bit more reverse engineering of the material format, but I think the main thing would be loading the base material and grabbing the actual DirectX byte code from the base material's gpu data

Here's a screen cap of the widget as it stands:
![image](https://github.com/user-attachments/assets/0ad469a7-4195-482a-a91c-776eb37e462a)
