### PR TITLE
Add a few improvements to initial material preview

### DIFF
--- a/stingray/triad.go
+++ b/stingray/triad.go
@@ -252,7 +252,8 @@ func (f *containedFile) Close() error {
 	return f.f.Close()
 }
 
-// OpenFile attempts to open
+// OpenFile attempts to open the file with the given index and type
+// within the Triad.
 // Returns a wrapped version of ErrFileDataTypeNotExist when the file exists,
 // but doesn't have the requested data type.
 // Call Close() on returned reader when done.


### PR DESCRIPTION
Amends #97 

Changes:
- Allow cycling through images using arrow keys
- Make setting keys copyable (could be especially useful for further researching unknown keys)
- Some materials reference non-existant textures (e.g. `0x009783bb2c610800.material`), improve the error message in that case
- Add tolerance for when the zero texture (0x0.texture) is referenced (e.g. `0x0591fb957a6f97e6.material`)
- Sort textures by usage so they always appear in the same order