### PR TITLE
Blender 4.5 Importer Fixes

### DIFF
--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -343,6 +343,7 @@ func ConvertBuffer(fMain, fGPU io.ReadSeekCloser, filename stingray.Hash, ctx ex
 			return err
 		}
 	}
+	doc.Scenes[0].Nodes = append(doc.Scenes[0].Nodes, meshNodes...)
 
 	AddPrefabMetadata(ctx, doc, filename, parent, skin, meshNodes, armorSetName)
 


### PR DESCRIPTION
Blender's GLTF importer no longer considers children of nodes in the scene as included in the scene, so all nodes must be added to the scene. Otherwise they are "orphan nodes" that are imported but excluded from the tree, causing errors when exporting