### PR TITLE
If a closeable glb has no buffers, do not export it on close

### DIFF
--- a/extractor/single_glb_helper/single_glb_helper.go
+++ b/extractor/single_glb_helper/single_glb_helper.go
@@ -1,6 +1,7 @@
 package single_glb_helper
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -20,15 +21,18 @@ func CreateCloseableGltfDocument(outDir string, triad string, formatBlend bool, 
 	})
 	closeGLB := func(doc *gltf.Document) error {
 		outPath := filepath.Join(outDir, triad)
+		if len(document.Buffers) == 0 {
+			return nil
+		}
 		if formatBlend {
 			err := blend_helper.ExportBlend(doc, outPath, runner)
 			if err != nil {
-				return err
+				return fmt.Errorf("closing %v.blend: %v", outPath, err)
 			}
 		} else {
 			err := exportGLB(doc, outPath)
 			if err != nil {
-				return err
+				return fmt.Errorf("closing %v.glb: %v", outPath, err)
 			}
 		}
 		return nil


### PR DESCRIPTION
We were seeing error messages when files were extracted using the --unit-single-file flag - these turned out to be caused because we create all three combined file types when we use that flag, but only add to them if one of the file types is present in the export (unit, geometry_group, or material). When the blend exporter is invoked with an empty file, it generates an error, which was causing the error messages we were seeing.

To prevent this, I've added a check when closing a GLB file to ensure it has some data in it before invoking the exporter. Also I've made the error messages a bit more informative so hopefully they'll be more helpful in the future