### PR TITLE
Correct fix for orphan meshes problem

### DIFF
--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -882,9 +882,8 @@ func LoadGLTF(ctx extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, nam
 			node := uint32(len(doc.Nodes)) - 1
 			if _, contains := primitives[0].Attributes[gltf.JOINTS_0]; contains {
 				doc.Nodes[node].Skin = skin
-			} else {
-				doc.Nodes[parent].Children = append(doc.Nodes[parent].Children, node)
 			}
+			doc.Nodes[parent].Children = append(doc.Nodes[parent].Children, node)
 			*meshNodes = append(*meshNodes, node)
 		}
 	}

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -343,7 +343,6 @@ func ConvertBuffer(fMain, fGPU io.ReadSeekCloser, filename stingray.Hash, ctx ex
 			return err
 		}
 	}
-	doc.Scenes[0].Nodes = append(doc.Scenes[0].Nodes, meshNodes...)
 
 	AddPrefabMetadata(ctx, doc, filename, parent, skin, meshNodes, armorSetName)
 


### PR DESCRIPTION
Apparently skinned meshes were not having their mesh nodes added as children of the correct node, causing blender to count them as orphaned. The previous fix to add all mesh nodes to the scene was a workaround that caused issues when non-skinned meshes were added to the file, because their mesh nodes were correctly added as children.

Fixes #117