### PR TITLE
Load armor set strings by language rather than by a specific strings file

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -217,6 +217,11 @@ func OpenGameDir(ctx context.Context, gameDir string, hashStrings []string, thin
 		if err != nil || strings.Language != language {
 			continue
 		}
+		for id := range strings.Strings {
+			if _, contains := mapping[id]; contains {
+				panic(fmt.Errorf("ID %v was already contained in the mapping!\n", id))
+			}
+		}
 
 		maps.Copy(mapping, strings.Strings)
 	}

--- a/cmd/filediver-cli/main.go
+++ b/cmd/filediver-cli/main.go
@@ -95,9 +95,9 @@ func main() {
 		optInclArchives = argp.String("t", "triads", &argparse.Option{
 			Help: "include comma-separated archive name(s) [formerly triads] as found in game data directory, e.g. 0x9ba626afa44a3aa3",
 		})
-		langs := make([]any, len(stingray_strings.FriendlyNames))
+		langs := make([]any, len(stingray_strings.LanguageFriendlyNames))
 		for i := range langs {
-			langs[i] = stingray_strings.FriendlyNames[i]
+			langs[i] = stingray_strings.LanguageFriendlyNames[i]
 		}
 		optArmorStringsLanguage = argp.String("s", "strings-language", &argparse.Option{
 			Default: "English (US)",
@@ -219,7 +219,7 @@ func main() {
 		cancel()
 	}()
 
-	a, err := app.OpenGameDir(ctx, gamedir, knownHashes, knownThinHashes, stingray_strings.FriendlyNameToHash[*optArmorStringsLanguage], func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gamedir, knownHashes, knownThinHashes, stingray_strings.LanguageFriendlyNameToHash[*optArmorStringsLanguage], func(curr, total int) {
 		prt.Statusf("Reading metadata %.0f%%", float64(curr)/float64(total)*100)
 	})
 	if err != nil {

--- a/cmd/filediver-gui/game_data_manager.go
+++ b/cmd/filediver-gui/game_data_manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/xypwn/filediver/extractor/single_glb_helper"
 	"github.com/xypwn/filediver/hashes"
 	"github.com/xypwn/filediver/stingray"
+	stingray_strings "github.com/xypwn/filediver/stingray/strings"
 )
 
 type GameDataExport struct {
@@ -178,7 +179,7 @@ func (gd *GameDataLoad) loadGameData(ctx context.Context, gameDir string) {
 		}
 	}
 
-	a, err := app.OpenGameDir(ctx, gameDir, app.ParseHashes(hashes.Hashes), app.ParseHashes(hashes.ThinHashes), stingray.Hash{Value: 0x7c7587b563f10985}, func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, app.ParseHashes(hashes.Hashes), app.ParseHashes(hashes.ThinHashes), stingray_strings.FriendlyNameToHash["English (US)"], func(curr, total int) {
 		gd.Lock()
 		gd.Progress = float32(curr+1) / float32(total)
 		gd.Unlock()

--- a/cmd/filediver-gui/game_data_manager.go
+++ b/cmd/filediver-gui/game_data_manager.go
@@ -179,7 +179,7 @@ func (gd *GameDataLoad) loadGameData(ctx context.Context, gameDir string) {
 		}
 	}
 
-	a, err := app.OpenGameDir(ctx, gameDir, app.ParseHashes(hashes.Hashes), app.ParseHashes(hashes.ThinHashes), stingray_strings.FriendlyNameToHash["English (US)"], func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, app.ParseHashes(hashes.Hashes), app.ParseHashes(hashes.ThinHashes), stingray_strings.LanguageFriendlyNameToHash["English (US)"], func(curr, total int) {
 		gd.Lock()
 		gd.Progress = float32(curr+1) / float32(total)
 		gd.Unlock()

--- a/cmd/filediver-gui/widgets/previews/strings_preview.go
+++ b/cmd/filediver-gui/widgets/previews/strings_preview.go
@@ -39,7 +39,7 @@ func (pv *StringsPreviewState) Load(data *stingray_strings.Strings, thinhashes m
 	}
 	if data.Count == 0 {
 		pv.languageFriendlyName = "None"
-	} else if fn, ok := stingray_strings.LanguageFriendlyName[data.Language]; ok {
+	} else if fn, ok := stingray_strings.LanguageHashToFriendlyName[data.Language]; ok {
 		pv.languageFriendlyName = fn
 	} else {
 		pv.languageFriendlyName = "Unknown"

--- a/cmd/tools/animation-name-dumper/main.go
+++ b/cmd/tools/animation-name-dumper/main.go
@@ -63,7 +63,7 @@ func main() {
 	knownHashes := app.ParseHashes(hashes.Hashes)
 	knownThinHashes := app.ParseHashes(hashes.ThinHashes)
 
-	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray.Hash{}, func(curr int, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray.ThinHash{}, func(curr int, total int) {
 		prt.Statusf("Opening game directory %.0f%%", float64(curr)/float64(total)*100)
 	})
 	if err != nil {

--- a/cmd/tools/crossref-checker/main.go
+++ b/cmd/tools/crossref-checker/main.go
@@ -198,7 +198,7 @@ func main() {
 
 	ctx := context.Background() // no need to exit cleanly since we're only reading
 	knownHashes := app.ParseHashes(hashes.Hashes)
-	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, []string{}, stingray.Hash{}, func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, []string{}, stingray.ThinHash{}, func(curr, total int) {
 		prt.Statusf("Reading metadata %.0f%%", float64(curr)/float64(total)*100)
 	})
 	if err != nil {

--- a/cmd/tools/hd2grep/main.go
+++ b/cmd/tools/hd2grep/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	ctx := context.Background() // no need to exit cleanly since we're only reading
 	knownHashes := app.ParseHashes(hashes.Hashes)
-	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, []string{}, stingray.Hash{}, func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, []string{}, stingray.ThinHash{}, func(curr, total int) {
 		prt.Statusf("Reading metadata %.0f%%", float64(curr)/float64(total)*100)
 	})
 	if err != nil {

--- a/cmd/tools/physics-name-dumper/main.go
+++ b/cmd/tools/physics-name-dumper/main.go
@@ -60,7 +60,7 @@ func main() {
 	knownHashes := app.ParseHashes(hashes.Hashes)
 	knownThinHashes := app.ParseHashes(hashes.ThinHashes)
 
-	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray.Hash{}, func(curr int, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray.ThinHash{}, func(curr int, total int) {
 		prt.Statusf("Opening game directory %.0f%%", float64(curr)/float64(total)*100)
 	})
 	if err != nil {

--- a/cmd/tools/strings-language-dumper/main.go
+++ b/cmd/tools/strings-language-dumper/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	ctx := context.Background() // no need to exit cleanly since we're only reading
 	knownHashes := app.ParseHashes(hashes.Hashes)
-	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, []string{}, stingray.Hash{}, func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, []string{}, stingray.ThinHash{}, func(curr, total int) {
 		prt.Statusf("Reading metadata %.0f%%", float64(curr)/float64(total)*100)
 	})
 	if err != nil {

--- a/extractor/strings/extractor.go
+++ b/extractor/strings/extractor.go
@@ -49,7 +49,7 @@ func ExtractStringsJSON(ctx *extractor.Context) error {
 		if n, ok := ctx.ThinHashes()[strings.Language]; ok {
 			lang.KnownName = n
 		}
-		if fn, ok := stingray_strings.LanguageFriendlyName[strings.Language]; ok {
+		if fn, ok := stingray_strings.LanguageHashToFriendlyName[strings.Language]; ok {
 			lang.KnownFriendlyName = fn
 		}
 		simpleStrings.Language = lang

--- a/hashes/generate/wwise_streams/main.go
+++ b/hashes/generate/wwise_streams/main.go
@@ -34,7 +34,7 @@ func main() {
 		prt.Fatalf("Command line option for installation path not implemented in wwise_streams generator. Please open an issue on GitHub")
 	}
 	ctx := context.Background() // no need to exit cleanly since we're only reading
-	a, err := app.OpenGameDir(ctx, gameDir, nil, nil, stingray.Hash{}, func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, nil, nil, stingray.ThinHash{}, func(curr, total int) {
 		prt.Statusf("Reading metadata %.0f%%", float64(curr)/float64(total)*100)
 	})
 	if err != nil {

--- a/scripts/export_armor_sets.py
+++ b/scripts/export_armor_sets.py
@@ -1,20 +1,23 @@
 from dlbin import DlBin, HelldiverCustomizationKit
-from strings import Strings
+from strings import Strings, SUPPORTED_LANGUAGE_NAMES, Language
 
 from io import BytesIO
 from pathlib import Path
+from typing import Dict
 import json
 
 from argparse import ArgumentParser
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument("-strings", "-s", type=Path, help="Path to .strings file to use for mapping armor set names (0x7c7587b563f10985.strings is en_us)")
+    parser.add_argument("-strings-dir", "-s", type=Path, help="Path to directory of strings files to use for mapping armor set names")
+    parser.add_argument("-language", "-l", default="en-us", choices=SUPPORTED_LANGUAGE_NAMES)
     parser.add_argument("armor_sets", type=Path, help="Path to decrypted generated_customization_armor_sets.dl_bin")
     args = parser.parse_args()
 
     armor_sets: Path = args.armor_sets
-    strings_path: Path = args.strings
+    strings_dir: Path = args.strings_dir
+    language: Language = Language.from_string(args.language)
 
     with armor_sets.open("rb") as f:
         data = f.read()
@@ -23,12 +26,24 @@ def main():
 
     json_out = []
 
-    with strings_path.open("rb") as f:
-        strings = Strings.parse(f).mapping
+    mapping: Dict[int, str] = {}
+    for strings_file in strings_dir.iterdir():
+        if not strings_file.is_file():
+            continue
+        if strings_file.suffix not in [".strings", ".main"]:
+            continue
+        with strings_file.open("rb") as f:
+            try:
+                strings = Strings.parse(f)
+                if strings.language != language:
+                    continue
+                mapping.update(strings.mapping)
+            except:
+                continue
 
     for item in dlbin.items:
         content: HelldiverCustomizationKit = item.content
-        json_out.append(content.to_json(strings))
+        json_out.append(content.to_json(mapping))
 
     print(json.dumps(json_out, indent=4))
 

--- a/scripts/strings/__init__.py
+++ b/scripts/strings/__init__.py
@@ -1,6 +1,7 @@
 import struct
 from io import BytesIO
 from typing import List, Dict
+from enum import IntEnum
 
 def read_cstr(data: BytesIO) -> str:
     to_return = ""
@@ -13,11 +14,100 @@ def read_cstr(data: BytesIO) -> str:
         char = data.read(1)
     return to_return
 
+class Language(IntEnum):
+    DE      = 0xba39c3ec
+    ES      = 0x31806842
+    ES_MX   = 0xe5c65a36
+    EN_GB   = 0x6f4515cb
+    EN_US   = 0x03f97b57
+    FR      = 0xfea0f61f
+    IT      = 0xe2fb1acd
+    JA      = 0x90b6af29
+    KO      = 0xbbd7b5d1
+    NL      = 0x11592f05
+    PL      = 0x0f8857aa
+    PT      = 0x4a2ca9c9
+    PT_BR   = 0x6ef58def
+    RU      = 0xc5bb18ed
+    ZH_HANS = 0x82874cc2
+    ZH_HANT = 0x9eba952a
+
+    @classmethod
+    def from_string(cls, name: str):
+        if name.lower() == "de" or name.lower() == "german":
+            return cls.DE
+        if name.lower() == "es" or name.lower() == "spanish":
+            return cls.ES
+        if name.lower() == "es-mx" or name.lower() == "spanish (mexico)":
+            return cls.ES_MX
+        if name.lower() == "en-gb" or name.lower() == "english (uk)":
+            return cls.EN_GB
+        if name.lower() == "en-us" or name.lower() == "english (us)":
+            return cls.EN_US
+        if name.lower() == "fr" or name.lower() == "french":
+            return cls.FR
+        if name.lower() == "it" or name.lower() == "italian":
+            return cls.IT
+        if name.lower() == "ja" or name.lower() == "japanese":
+            return cls.JA
+        if name.lower() == "ko" or name.lower() == "korean":
+            return cls.KO
+        if name.lower() == "nl" or name.lower() == "dutch":
+            return cls.NL
+        if name.lower() == "pl" or name.lower() == "polish":
+            return cls.PL
+        if name.lower() == "pt" or name.lower() == "portuguese":
+            return cls.PT
+        if name.lower() == "pt-br" or name.lower() == "portuguese (brazil)":
+            return cls.PT_BR
+        if name.lower() == "ru" or name.lower() == "russian":
+            return cls.RU
+        if name.lower() == "zh-hans" or name.lower() == "simplified chinese":
+            return cls.ZH_HANS
+        if name.lower() == "zh-hant" or name.lower() == "traditional chinese":
+            return cls.ZH_HANT
+        raise ValueError(f"{name} is not a supported language")
+
+SUPPORTED_LANGUAGE_NAMES = [
+    "de",
+    "es",
+    "es-mx",
+    "en-gb",
+    "en-us",
+    "fr",
+    "it",
+    "ja",
+    "ko",
+    "nl",
+    "pl",
+    "pt",
+    "pt-br",
+    "ru",
+    "zh-hans",
+    "zh-hant",
+    "German",
+    "Spanish",
+    "Spanish (Mexico)",
+    "English (UK)",
+    "English (US)",
+    "French",
+    "Italian",
+    "Japanese",
+    "Korean",
+    "Dutch",
+    "Polish",
+    "Portuguese",
+    "Portuguese (Brazil)",
+    "Russian",
+    "Simplified Chinese",
+    "Traditional Chinese"
+]
+
 class Strings:
-    def __init__(self, magic: int, version: int, hash_maybe: int, string_ids: List[int], strings: List[str]):
+    def __init__(self, magic: int, version: int, language: int, string_ids: List[int], strings: List[str]):
         self.magic = magic
         self.version = version
-        self.hash_maybe = hash_maybe
+        self.language = language
         self.string_ids = string_ids
         self.strings = strings
         self.mapping: Dict[int, str] = {key: val for key, val in zip(string_ids, strings)}
@@ -27,14 +117,14 @@ class Strings:
         magic, version, count = struct.unpack("<III", data.read(12))
         if count == 0:
             return cls(magic, version, 0, [], [])
-        unk = struct.unpack("<I", data.read(4))[0]
+        language = struct.unpack("<I", data.read(4))[0]
         string_ids = [val[0] for val in struct.iter_unpack("<I", data.read(4 * count))]
         string_offsets = [val[0] for val in struct.iter_unpack("<I", data.read(4 * count))]
         strings = []
         for offset in string_offsets:
             data.seek(offset)
             strings.append(read_cstr(data))
-        return cls(magic, version, unk, string_ids, strings)
+        return cls(magic, version, language, string_ids, strings)
 
     def __getitem__(self, key: int):
         return self.mapping[key]

--- a/stingray/dl_bin/dl_bin.go
+++ b/stingray/dl_bin/dl_bin.go
@@ -339,11 +339,13 @@ func LoadArmorSetDefinitions(strings map[uint32]string) (map[stingray.Hash]Armor
 		return nil, fmt.Errorf("fs.File does not implement io.ReadSeeker (but it should so this should not happen)")
 	}
 
-	getNameIfContained := func(id uint32) string {
-		if name, contains := strings[id]; contains {
+	getNameIfContained := func(casedId, upperId uint32) string {
+		if name, contains := stringsMap[casedId]; contains {
+			return name
+		} else if name, contains := stringsMap[upperId]; contains {
 			return name
 		} else {
-			return fmt.Sprintf("%x", id)
+			return fmt.Sprintf("%x", casedId)
 		}
 	}
 
@@ -367,7 +369,7 @@ func LoadArmorSetDefinitions(strings map[uint32]string) (map[stingray.Hash]Armor
 		}
 
 		armorSet := ArmorSet{
-			Name:         getNameIfContained(item.Kit.NameCased),
+			Name:         getNameIfContained(item.Kit.NameCased, item.Kit.NameUpper),
 			SetId:        item.Kit.SetId,
 			Passive:      item.Kit.Passive,
 			Type:         item.Kit.Type,

--- a/stingray/dl_bin/dl_bin.go
+++ b/stingray/dl_bin/dl_bin.go
@@ -340,9 +340,9 @@ func LoadArmorSetDefinitions(strings map[uint32]string) (map[stingray.Hash]Armor
 	}
 
 	getNameIfContained := func(casedId, upperId uint32) string {
-		if name, contains := stringsMap[casedId]; contains {
+		if name, contains := strings[casedId]; contains {
 			return name
-		} else if name, contains := stringsMap[upperId]; contains {
+		} else if name, contains := strings[upperId]; contains {
 			return name
 		} else {
 			return fmt.Sprintf("%x", casedId)

--- a/stingray/strings/strings.go
+++ b/stingray/strings/strings.go
@@ -29,6 +29,44 @@ var LanguageFriendlyName = map[stingray.ThinHash]string{
 	stingray.Sum("us").Thin(): "English (US)",
 }
 
+var FriendlyNameToHash = map[string]stingray.ThinHash{
+	"Portuguese (Brazil)":   stingray.Sum("bp").Thin(),
+	"German":                stingray.Sum("de").Thin(),
+	"Spanish (Spain)":       stingray.Sum("es").Thin(),
+	"French":                stingray.Sum("fr").Thin(),
+	"English (UK)":          stingray.Sum("gb").Thin(),
+	"Italian":               stingray.Sum("it").Thin(),
+	"Japanese":              stingray.Sum("jp").Thin(),
+	"Korean":                stingray.Sum("ko").Thin(),
+	"Spanish (Mexico)":      stingray.Sum("ms").Thin(),
+	"Dutch":                 stingray.Sum("nl").Thin(),
+	"Polish":                stingray.Sum("pl").Thin(),
+	"Portuguese (Europe)":   stingray.Sum("pt").Thin(),
+	"Russian":               stingray.Sum("ru").Thin(),
+	"Chinese (Simplified)":  stingray.Sum("sc").Thin(),
+	"Chinese (Traditional)": stingray.Sum("tc").Thin(),
+	"English (US)":          stingray.Sum("us").Thin(),
+}
+
+var FriendlyNames = []string{
+	"Chinese (Simplified)",
+	"Chinese (Traditional)",
+	"Dutch",
+	"English (UK)",
+	"English (US)",
+	"French",
+	"German",
+	"Italian",
+	"Japanese",
+	"Korean",
+	"Polish",
+	"Portuguese (Brazil)",
+	"Portuguese (Europe)",
+	"Russian",
+	"Spanish (Spain)",
+	"Spanish (Mexico)",
+}
+
 type Strings struct {
 	Magic    [4]byte
 	Version  uint32

--- a/stingray/strings/strings.go
+++ b/stingray/strings/strings.go
@@ -10,7 +10,7 @@ import (
 	"github.com/xypwn/filediver/stingray"
 )
 
-var LanguageFriendlyName = map[stingray.ThinHash]string{
+var LanguageHashToFriendlyName = map[stingray.ThinHash]string{
 	stingray.Sum("bp").Thin(): "Portuguese (Brazil)",
 	stingray.Sum("de").Thin(): "German",
 	stingray.Sum("es").Thin(): "Spanish (Spain)",
@@ -29,42 +29,16 @@ var LanguageFriendlyName = map[stingray.ThinHash]string{
 	stingray.Sum("us").Thin(): "English (US)",
 }
 
-var FriendlyNameToHash = map[string]stingray.ThinHash{
-	"Portuguese (Brazil)":   stingray.Sum("bp").Thin(),
-	"German":                stingray.Sum("de").Thin(),
-	"Spanish (Spain)":       stingray.Sum("es").Thin(),
-	"French":                stingray.Sum("fr").Thin(),
-	"English (UK)":          stingray.Sum("gb").Thin(),
-	"Italian":               stingray.Sum("it").Thin(),
-	"Japanese":              stingray.Sum("jp").Thin(),
-	"Korean":                stingray.Sum("ko").Thin(),
-	"Spanish (Mexico)":      stingray.Sum("ms").Thin(),
-	"Dutch":                 stingray.Sum("nl").Thin(),
-	"Polish":                stingray.Sum("pl").Thin(),
-	"Portuguese (Europe)":   stingray.Sum("pt").Thin(),
-	"Russian":               stingray.Sum("ru").Thin(),
-	"Chinese (Simplified)":  stingray.Sum("sc").Thin(),
-	"Chinese (Traditional)": stingray.Sum("tc").Thin(),
-	"English (US)":          stingray.Sum("us").Thin(),
-}
+var LanguageFriendlyNameToHash map[string]stingray.ThinHash
+var LanguageFriendlyNames []string
 
-var FriendlyNames = []string{
-	"Chinese (Simplified)",
-	"Chinese (Traditional)",
-	"Dutch",
-	"English (UK)",
-	"English (US)",
-	"French",
-	"German",
-	"Italian",
-	"Japanese",
-	"Korean",
-	"Polish",
-	"Portuguese (Brazil)",
-	"Portuguese (Europe)",
-	"Russian",
-	"Spanish (Spain)",
-	"Spanish (Mexico)",
+func init() {
+	LanguageFriendlyNameToHash = make(map[string]stingray.ThinHash)
+	LanguageFriendlyNames = make([]string, 0)
+	for hash, value := range LanguageHashToFriendlyName {
+		LanguageFriendlyNameToHash[value] = hash
+		LanguageFriendlyNames = append(LanguageFriendlyNames, value)
+	}
 }
 
 type Strings struct {


### PR DESCRIPTION
Loads all strings files of a particular language when searching for armor set strings - this likely needs to be extended to just allow us to reference strings from anywhere rather than just armor sets, so we can reuse this system when other things have strings we'd like to export (weapon attachments? other things defined by dlbins?)