### PR TITLE
Vertex Normal Unpacking support

### DIFF
--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"slices"
 	"strings"
 
@@ -47,6 +48,26 @@ func convertFloat16Slice(gpuR io.ReadSeeker, data []byte, tmpArr []uint16, extra
 	return data, size, nil
 }
 
+func sign(f float64) float64 {
+	if math.Signbit(f) {
+		return -1
+	}
+	return 1
+}
+
+func decodePackedNormal(normal uint32) mgl32.Vec3 {
+	x10 := normal & 0x3ff
+	y10 := (normal >> 10) & 0x3ff
+	x, y := float64(x10)*(2.0/1023.0)-1, float64(y10)*(2.0/1023.0)-1
+	z := 1 - math.Abs(x) - math.Abs(y)
+
+	if z < 0 {
+		x, y = (1-math.Abs(y))*sign(x), (1-math.Abs(x))*sign(y)
+	}
+
+	return mgl32.Vec3{float32(x), float32(y), float32(z)}.Normalize()
+}
+
 func convertVertices(gpuR io.ReadSeeker, layout unit.MeshLayout) ([]byte, []AccessorInfo, error) {
 	data := make([]byte, 0)
 	dataLen := len(data)
@@ -82,14 +103,12 @@ func convertVertices(gpuR io.ReadSeeker, layout unit.MeshLayout) ([]byte, []Acce
 				}
 			case unit.FormatVec4R10G10B10A2_UNORM:
 				var tmp uint32
-				var val [3]float32
+				var val mgl32.Vec3
 				var err error
 				if err = binary.Read(gpuR, binary.LittleEndian, &tmp); err != nil {
 					return nil, nil, fmt.Errorf("reading gpu data: %v", err)
 				}
-				val[0] = float32(tmp&0x3ff) / 1023.0
-				val[1] = float32((tmp>>10)&0x3ff) / 1023.0
-				val[2] = float32((tmp>>20)&0x3ff) / 1023.0
+				val = decodePackedNormal(tmp)
 				data, err = binary.Append(data, binary.LittleEndian, val)
 				if err != nil {
 					return nil, nil, fmt.Errorf("adding packed vec4 unorm to data: %v", err)
@@ -298,7 +317,7 @@ func createAttributes(doc *gltf.Document, layout unit.MeshLayout, accessorInfo [
 		case unit.ItemPosition:
 			attributes[gltf.POSITION] = accessor
 		case unit.ItemNormal:
-			attributes["COLOR_1"] = accessor
+			attributes[gltf.NORMAL] = accessor
 		case unit.ItemUVCoords:
 			attributes[fmt.Sprintf("TEXCOORD_%v", layout.Items[j].Layer)] = accessor
 		case unit.ItemBoneIdx:
@@ -690,9 +709,9 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 
 		udimPrimitives := make(map[uint32][]*gltf.Primitive)
 		nodeName := fmt.Sprintf("%v %v", unitName, groupName)
-		var transformed bool = false
 		remapped := make(map[uint32]bool)
-		var previousPositionAccessor *gltf.Accessor
+		var transformedPositions, transformedNormals bool = false, false
+		var previousPositionAccessor, previousNormalAccessor *gltf.Accessor
 		for j, group := range header.Groups {
 			// Check if this group is a gib or collision mesh, if it is skip it unless include_lods is set
 			var materialName string
@@ -778,7 +797,7 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 					// Check if there are vertices that still need to be transformed
 					vertexOffset = previousPositionAccessor.Count
 				}
-				if !((transformed && vertexOffset == 0) || transformMatrix.ApproxEqual(mgl32.Ident4())) {
+				if !((transformedPositions && vertexOffset == 0) || transformMatrix.ApproxEqual(mgl32.Ident4())) {
 					// Only transform vertices once, and only perform the multiplications if the transform does something
 					bufferOffset := doc.Accessors[positionAccessor].ByteOffset + doc.BufferViews[vertexBuffer].ByteOffset
 					stride := doc.BufferViews[vertexBuffer].ByteStride
@@ -787,9 +806,29 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 					if err != nil {
 						return err
 					}
-					transformed = true
+					transformedPositions = true
 				}
 				previousPositionAccessor = doc.Accessors[positionAccessor]
+			}
+
+			if normalAccessor, contains := groupAttr[gltf.NORMAL]; contains {
+				var vertexOffset uint32 = 0
+				if previousNormalAccessor != nil && previousNormalAccessor.Count < doc.Accessors[normalAccessor].Count {
+					// Check if there are vertices that still need to be transformed
+					vertexOffset = previousNormalAccessor.Count
+				}
+				if !((transformedNormals && vertexOffset == 0) || transformMatrix.ApproxEqual(mgl32.Ident4())) {
+					// Only transform vertices once, and only perform the multiplications if the transform does something
+					bufferOffset := doc.Accessors[normalAccessor].ByteOffset + doc.BufferViews[vertexBuffer].ByteOffset
+					stride := doc.BufferViews[vertexBuffer].ByteStride
+					buffer := doc.Buffers[doc.BufferViews[vertexBuffer].Buffer]
+					err := transformVertices(buffer, bufferOffset, stride, vertexOffset, doc.Accessors[normalAccessor].Count, transformMatrix)
+					if err != nil {
+						return err
+					}
+					transformedNormals = true
+				}
+				previousNormalAccessor = doc.Accessors[normalAccessor]
 			}
 
 			_, beenRemapped := remapped[*groupIndices]

--- a/extractor/single_glb_helper/single_glb_helper.go
+++ b/extractor/single_glb_helper/single_glb_helper.go
@@ -20,17 +20,17 @@ func CreateCloseableGltfDocument(outDir string, name string, formatBlend bool, r
 		WrapT:     gltf.WrapRepeat,
 	})
 	closeGLB := func(doc *gltf.Document) error {
-		outPath := filepath.Join(outDir, name+".blend")
+		outPath := filepath.Join(outDir, name)
 		if len(document.Buffers) == 0 {
 			return nil
 		}
 		if formatBlend {
-			err := blend_helper.ExportBlend(doc, outPath, runner)
+			err := blend_helper.ExportBlend(doc, outPath+".blend", runner)
 			if err != nil {
 				return fmt.Errorf("closing %v.blend: %v", outPath, err)
 			}
 		} else {
-			err := exportGLB(doc, outPath)
+			err := exportGLB(doc, outPath+".glb")
 			if err != nil {
 				return fmt.Errorf("closing %v.glb: %v", outPath, err)
 			}
@@ -41,11 +41,10 @@ func CreateCloseableGltfDocument(outDir string, name string, formatBlend bool, r
 }
 
 func exportGLB(doc *gltf.Document, outPath string) error {
-	path := outPath + ".glb"
-	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
 		return err
 	}
-	out, err := os.Create(path)
+	out, err := os.Create(outPath)
 	if err != nil {
 		return err
 	}

--- a/scripts/hd2_accurate_blender_importer.py
+++ b/scripts/hd2_accurate_blender_importer.py
@@ -247,7 +247,7 @@ def main():
         if "extras" in gltf and "frameRate" in gltf["extras"]:
             print(f'Setting FPS to {gltf["extras"]["frameRate"]}')
             bpy.context.scene.render.fps = gltf["extras"]["frameRate"]
-        bpy.ops.import_scene.gltf(filepath=str(path), import_shading="SMOOTH", bone_heuristic="TEMPERANCE")
+        bpy.ops.import_scene.gltf(filepath=str(path), import_shading="NORMALS", bone_heuristic="TEMPERANCE")
     finally:
         if str(input_model) == "-":
             path.unlink()
@@ -366,11 +366,6 @@ def main():
                     break
             shader_module.add_bake_uvs(obj)
             obj.select_set(True)
-            try:
-                bpy.ops.object.shade_smooth()
-            except RuntimeError:
-                # Context incorrect? We don't actually need to do this so its okay if it fails
-                pass
             print(f"Applied material to {node['name']}!")
 
     bpy.ops.wm.save_mainfile(filepath=str(output))


### PR DESCRIPTION
- Unpack vertex normals according to octahedral encoding
- Correctly import normals in the importer script
- Fix naming of exported single-file glbs (previously would name them xxxx.blend.glb)