### PR TITLE
Only rotate normals on vertex transform

### DIFF
--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -825,7 +825,8 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 					bufferOffset := doc.Accessors[normalAccessor].ByteOffset + doc.BufferViews[vertexBuffer].ByteOffset
 					stride := doc.BufferViews[vertexBuffer].ByteStride
 					buffer := doc.Buffers[doc.BufferViews[vertexBuffer].Buffer]
-					err := transformVertices(buffer, bufferOffset, stride, vertexOffset, doc.Accessors[normalAccessor].Count, transformMatrix)
+					// Only use the rotation matrix to transform normals
+					err := transformVertices(buffer, bufferOffset, stride, vertexOffset, doc.Accessors[normalAccessor].Count, transformMatrix.Mat3().Mat4())
 					if err != nil {
 						return err
 					}

--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -831,6 +831,23 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 					buffer := doc.Buffers[doc.BufferViews[vertexBuffer].Buffer]
 					// Only use the rotation matrix to transform normals
 					rotationMatrix := transformMatrix.Mat3().Mat4()
+
+					scaleX := rotationMatrix.Col(0).Len()
+					scaleY := rotationMatrix.Col(1).Len()
+					scaleZ := rotationMatrix.Col(2).Len()
+
+					rotationMatrix[0] /= scaleX
+					rotationMatrix[3] /= scaleX
+					rotationMatrix[6] /= scaleX
+
+					rotationMatrix[1] /= scaleY
+					rotationMatrix[4] /= scaleY
+					rotationMatrix[7] /= scaleY
+
+					rotationMatrix[2] /= scaleZ
+					rotationMatrix[5] /= scaleZ
+					rotationMatrix[8] /= scaleZ
+
 					err := transformVertices(buffer, bufferOffset, stride, vertexOffset, doc.Accessors[normalAccessor].Count, rotationMatrix)
 					if err != nil {
 						return err

--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -836,17 +836,7 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 					scaleY := rotationMatrix.Col(1).Len()
 					scaleZ := rotationMatrix.Col(2).Len()
 
-					rotationMatrix[0] /= scaleX
-					rotationMatrix[3] /= scaleX
-					rotationMatrix[6] /= scaleX
-
-					rotationMatrix[1] /= scaleY
-					rotationMatrix[4] /= scaleY
-					rotationMatrix[7] /= scaleY
-
-					rotationMatrix[2] /= scaleZ
-					rotationMatrix[5] /= scaleZ
-					rotationMatrix[8] /= scaleZ
+					rotationMatrix = rotationMatrix.Mul4(mgl32.Scale3D(scaleX, scaleY, scaleZ).Inv())
 
 					err := transformVertices(buffer, bufferOffset, stride, vertexOffset, doc.Accessors[normalAccessor].Count, rotationMatrix)
 					if err != nil {


### PR DESCRIPTION
When I was transforming the normals I was mistakenly applying the position transform of the matrix to the normals, causing some weird problems for several meshes, especially armor. This PR fixes that issue.