### PR TITLE
Culling and Collision mesh filtering fixes

### DIFF
--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -662,7 +662,7 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 				return true
 			}
 			if strings.Contains(name, "cull") || strings.Contains(name, "collision") {
-				return true && !onlyModelAndShadow
+				return true && onlyModelAndShadow
 			}
 			return false
 		}
@@ -904,8 +904,6 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 					// For some reason neither of the hulk models are in the visibility masks, but an invalid filename is?
 					// Not sure how the game looks them up in this case, probably need to investigate more
 					mask, contains = visibilityMaskData[stingray.Sum("content/fac_cyborgs/cha_lieutenant/cha_lieutenant_assault")]
-				} else {
-					ctx.Warnf("visibilityMaskData does not contain %v, model will be written with udim numbers rather than names", unitName)
 				}
 			}
 			visibilityMasks = make(map[uint16]map[string]any)

--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -661,7 +661,7 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, na
 			if strings.Contains(name, "_LOD") && (!strings.Contains(name, "_LOD0") || haveBaseModel) {
 				return true
 			}
-			if strings.Contains(name, "cull") || strings.Contains(name, "collision") {
+			if strings.Contains(name, "cull") || strings.Contains(name, "collision") || strings.Contains(name, "_proxy") {
 				return true && onlyModelAndShadow
 			}
 			return false


### PR DESCRIPTION
Culling and collision meshes were appearing when they weren't being included. This PR fixes that issue and adds `_proxy` as a substring to be excluded when filtering meshes