### PR TITLE
Helldivers Build Info (ah_bin) support

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/xypwn/filediver/dds"
 	"github.com/xypwn/filediver/exec"
 	"github.com/xypwn/filediver/extractor"
+	extr_ah_bin "github.com/xypwn/filediver/extractor/ah_bin"
 	extr_animation "github.com/xypwn/filediver/extractor/animation"
 	extr_bik "github.com/xypwn/filediver/extractor/bik"
 	extr_bones "github.com/xypwn/filediver/extractor/bones"
@@ -593,6 +594,8 @@ func (a *App) ExtractFile(ctx context.Context, id stingray.FileID, outDir string
 			extr = extr_package.ExtractPackageJSON
 		case "bones":
 			extr = extr_bones.ExtractBonesJSON
+		case "ah_bin":
+			extr = extr_ah_bin.ExtractAhBinJSON
 		default:
 			extr = getSourceExtractFunc(extrCfg, typ)
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -38,6 +38,7 @@ import (
 	extr_wwise "github.com/xypwn/filediver/extractor/wwise"
 	"github.com/xypwn/filediver/steampath"
 	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/stingray/ah_bin"
 	stingray_strings "github.com/xypwn/filediver/stingray/strings"
 	stingray_wwise "github.com/xypwn/filediver/stingray/wwise"
 	"github.com/xypwn/filediver/wwise"
@@ -115,6 +116,7 @@ type App struct {
 	DataDir            *stingray.DataDir
 	LanguageMap        map[uint32]string
 	Metadata           map[stingray.FileID]FileMetadata
+	GameBuildInfo      *ah_bin.BuildInfo
 }
 
 // Automatically gets most wwise-related hashes by reading the game files
@@ -339,6 +341,11 @@ func OpenGameDir(ctx context.Context, gameDir string, hashStrings []string, thin
 
 	mapping := stingray_strings.LoadLanguageMap(dataDir, language)
 
+	buildInfo, err := ah_bin.LoadFromDataDir(dataDir)
+	if err != nil && err != ah_bin.NotFound {
+		return nil, fmt.Errorf("error loading game build info: %v", err)
+	}
+
 	armorSets, err := datalib.LoadArmorSetDefinitions(mapping)
 	if err != nil {
 		return nil, fmt.Errorf("error loading armor set definitions: %v", err)
@@ -363,6 +370,7 @@ func OpenGameDir(ctx context.Context, gameDir string, hashStrings []string, thin
 		DataDir:            dataDir,
 		LanguageMap:        mapping,
 		Metadata:           getFileMetadata(dataDir),
+		GameBuildInfo:      buildInfo,
 	}, nil
 }
 
@@ -613,6 +621,7 @@ func (a *App) ExtractFile(ctx context.Context, id stingray.FileID, outDir string
 		a.ArmorSets,
 		a.SkinOverrideGroups,
 		a.WeaponPaintSchemes,
+		a.GameBuildInfo,
 		a.LanguageMap,
 		a.DataDir,
 		runner,

--- a/cmd/filediver-cli/main.go
+++ b/cmd/filediver-cli/main.go
@@ -581,7 +581,7 @@ Options:`)
 				default:
 					panic("unknown format: " + key)
 				}
-				doc, close := single_glb_helper.CreateCloseableGltfDocument(*optOutDir, name, formatBlend, runner)
+				doc, close := single_glb_helper.CreateCloseableGltfDocument(*optOutDir, name, formatBlend, runner, a.GameBuildInfo)
 				documents[key] = doc
 				documentsToClose = append(documentsToClose, func() error { return close(doc) })
 			}

--- a/cmd/filediver-gui/game_data_manager.go
+++ b/cmd/filediver-gui/game_data_manager.go
@@ -150,7 +150,7 @@ func (gd *GameData) GoExport(extractCtx context.Context, files []stingray.FileID
 				default:
 					panic("unknown format: " + key)
 				}
-				doc, close := single_glb_helper.CreateCloseableGltfDocument(outDir, name, formatBlend, runner)
+				doc, close := single_glb_helper.CreateCloseableGltfDocument(outDir, name, formatBlend, runner, gd.GameBuildInfo)
 				documents[key] = doc
 				documentsToClose = append(documentsToClose, func() error { return close(doc) })
 			}

--- a/cmd/tools/state-machine-event-state-dumper/main.go
+++ b/cmd/tools/state-machine-event-state-dumper/main.go
@@ -195,6 +195,7 @@ func main() {
 			a.ArmorSets,
 			a.SkinOverrideGroups,
 			a.WeaponPaintSchemes,
+			a.GameBuildInfo,
 			a.LanguageMap,
 			a.DataDir,
 			nil,

--- a/cmd/tools/state-machine-state-dumper/main.go
+++ b/cmd/tools/state-machine-state-dumper/main.go
@@ -173,6 +173,7 @@ func main() {
 			a.ArmorSets,
 			a.SkinOverrideGroups,
 			a.WeaponPaintSchemes,
+			a.GameBuildInfo,
 			a.LanguageMap,
 			a.DataDir,
 			nil,

--- a/extractor/ah_bin/ah_bin.go
+++ b/extractor/ah_bin/ah_bin.go
@@ -1,0 +1,28 @@
+package ah_bin
+
+import (
+	"encoding/json"
+
+	"github.com/xypwn/filediver/extractor"
+	"github.com/xypwn/filediver/stingray"
+	stingray_ah_bin "github.com/xypwn/filediver/stingray/ah_bin"
+)
+
+func ExtractAhBinJSON(ctx *extractor.Context) error {
+	r, err := ctx.Open(ctx.FileID(), stingray.DataMain)
+	if err != nil {
+		return err
+	}
+	buildInfo, err := stingray_ah_bin.LoadBuildInfo(r)
+
+	out, err := ctx.CreateFile(".ah.json")
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	enc := json.NewEncoder(out)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "    ")
+	err = enc.Encode(buildInfo)
+	return err
+}

--- a/extractor/context.go
+++ b/extractor/context.go
@@ -13,6 +13,7 @@ import (
 	datalib "github.com/xypwn/filediver/datalibrary"
 	"github.com/xypwn/filediver/exec"
 	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/stingray/ah_bin"
 )
 
 // Context is what's passed to the extractor when
@@ -27,6 +28,7 @@ type Context struct {
 	armorSets          map[stingray.Hash]datalib.ArmorSet
 	skinOverrideGroups []datalib.UnitSkinOverrideGroup
 	weaponPaintSchemes []datalib.WeaponCustomizableItem
+	gameBuildInfo      *ah_bin.BuildInfo
 	languageMap        map[uint32]string
 	dataDir            *stingray.DataDir
 	runner             *exec.Runner
@@ -54,6 +56,7 @@ func NewContext(
 	armorSets map[stingray.Hash]datalib.ArmorSet,
 	skinOverrideGroups []datalib.UnitSkinOverrideGroup,
 	weaponPaintSchemes []datalib.WeaponCustomizableItem,
+	gameBuildInfo *ah_bin.BuildInfo,
 	languageMap map[uint32]string,
 	dataDir *stingray.DataDir,
 	runner *exec.Runner,
@@ -69,6 +72,7 @@ func NewContext(
 		armorSets:          armorSets,
 		skinOverrideGroups: skinOverrideGroups,
 		weaponPaintSchemes: weaponPaintSchemes,
+		gameBuildInfo:      gameBuildInfo,
 		languageMap:        languageMap,
 		dataDir:            dataDir,
 		runner:             runner,
@@ -166,6 +170,10 @@ func (c *Context) ThinHashes() map[stingray.ThinHash]string {
 // LanguageMap returns a map of localization strings.
 func (c *Context) LanguageMap() map[uint32]string {
 	return c.languageMap
+}
+
+func (c *Context) BuildInfo() *ah_bin.BuildInfo {
+	return c.gameBuildInfo
 }
 
 // GuessFileArmorSet uses the selected archives (-t option)

--- a/extractor/geometry_group/extractor.go
+++ b/extractor/geometry_group/extractor.go
@@ -40,6 +40,9 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 	if doc == nil {
 		doc = gltf.NewDocument()
 		doc.Asset.Generator = "https://github.com/xypwn/filediver"
+		if ctx.BuildInfo() != nil {
+			doc.Scenes[0].Extras = map[string]any{"Helldivers 2 Version": ctx.BuildInfo().Version}
+		}
 		doc.Samplers = append(doc.Samplers, &gltf.Sampler{
 			MagFilter: gltf.MagLinear,
 			MinFilter: gltf.MinLinear,

--- a/extractor/material/extractor.go
+++ b/extractor/material/extractor.go
@@ -854,6 +854,9 @@ func convertOpts(ctx *extractor.Context, imgOpts *ImageOptions, gltfDoc *gltf.Do
 	if doc == nil {
 		doc = gltf.NewDocument()
 		doc.Asset.Generator = "https://github.com/xypwn/filediver"
+		if ctx.BuildInfo() != nil {
+			doc.Scenes[0].Extras = map[string]any{"Helldivers 2 Version": ctx.BuildInfo().Version}
+		}
 		doc.Samplers = append(doc.Samplers, &gltf.Sampler{
 			MagFilter: gltf.MagLinear,
 			MinFilter: gltf.MinLinear,

--- a/extractor/prefab/extractor.go
+++ b/extractor/prefab/extractor.go
@@ -27,6 +27,9 @@ func ConvertOpts(ctx *extractor.Context, gltfDoc *gltf.Document) error {
 	if doc == nil {
 		doc = gltf.NewDocument()
 		doc.Asset.Generator = "https://github.com/xypwn/filediver"
+		if ctx.BuildInfo() != nil {
+			doc.Scenes[0].Extras = map[string]any{"Helldivers 2 Version": ctx.BuildInfo().Version}
+		}
 		doc.Samplers = append(doc.Samplers, &gltf.Sampler{
 			MagFilter: gltf.MagLinear,
 			MinFilter: gltf.MinLinear,

--- a/extractor/single_glb_helper/single_glb_helper.go
+++ b/extractor/single_glb_helper/single_glb_helper.go
@@ -8,11 +8,15 @@ import (
 	"github.com/qmuntal/gltf"
 	"github.com/xypwn/filediver/exec"
 	"github.com/xypwn/filediver/extractor/blend_helper"
+	"github.com/xypwn/filediver/stingray/ah_bin"
 )
 
-func CreateCloseableGltfDocument(outDir string, name string, formatBlend bool, runner *exec.Runner) (*gltf.Document, func(doc *gltf.Document) error) {
+func CreateCloseableGltfDocument(outDir string, name string, formatBlend bool, runner *exec.Runner, buildInfo *ah_bin.BuildInfo) (*gltf.Document, func(doc *gltf.Document) error) {
 	document := gltf.NewDocument()
 	document.Asset.Generator = "https://github.com/xypwn/filediver"
+	if buildInfo != nil {
+		document.Scenes[0].Extras = map[string]any{"Helldivers 2 Version": buildInfo.Version}
+	}
 	document.Samplers = append(document.Samplers, &gltf.Sampler{
 		MagFilter: gltf.MagLinear,
 		MinFilter: gltf.MinLinear,

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -566,6 +566,9 @@ func ConvertBuffer(fMain, fGPU io.ReadSeeker, filename stingray.Hash, ctx *extra
 	if doc == nil {
 		doc = gltf.NewDocument()
 		doc.Asset.Generator = "https://github.com/xypwn/filediver"
+		if ctx.BuildInfo() != nil {
+			doc.Scenes[0].Extras = map[string]any{"Helldivers 2 Version": ctx.BuildInfo().Version}
+		}
 		doc.Samplers = append(doc.Samplers, &gltf.Sampler{
 			MagFilter: gltf.MagLinear,
 			MinFilter: gltf.MinLinear,

--- a/stingray/ah_bin/ah_bin.go
+++ b/stingray/ah_bin/ah_bin.go
@@ -1,0 +1,110 @@
+package ah_bin
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/xypwn/filediver/util"
+)
+
+type BuildInfo struct {
+	Commit   string `json:"commit"`
+	Hash     string `json:"hash"`
+	Version  string `json:"version"`
+	Combined string `json:"combined"`
+	Year     uint32 `json:"year"`
+	Month    uint32 `json:"month"`
+	Day      uint32 `json:"day"`
+	Hour     uint32 `json:"hour"`
+	Minute   uint32 `json:"minute"`
+	Second   uint32 `json:"second"`
+	BuildId  uint32 `json:"build_id"`
+}
+
+func LoadBuildInfo(r io.Reader) (*BuildInfo, error) {
+	commit, err := util.ReadCString(r)
+	if err != nil {
+		return nil, err
+	}
+
+	hash, err := util.ReadCStringWithSkip(r)
+	if err != nil {
+		return nil, err
+	}
+
+	version, err := util.ReadCStringWithSkip(r)
+	if err != nil {
+		return nil, err
+	}
+
+	combined, err := util.ReadCStringWithSkip(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var data []byte = make([]byte, 1)
+	for {
+		read, err := r.Read(data)
+		if read == 0 {
+			return nil, fmt.Errorf("string read past the end of r")
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		// Break reading string on null terminator
+		if data[0] != 0 {
+			break
+		}
+	}
+
+	data = append(data, 0, 0, 0)
+	_, err = r.Read(data[1:])
+	if err != nil {
+		return nil, err
+	}
+	var year, month, day, hour, minute, second, buildId uint32
+	if _, err := binary.Decode(data, binary.LittleEndian, &year); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, &month); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, &day); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, &hour); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, &minute); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, &second); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(r, binary.LittleEndian, &buildId); err != nil {
+		return nil, err
+	}
+
+	return &BuildInfo{
+		Commit:   *commit,
+		Hash:     *hash,
+		Version:  *version,
+		Combined: *combined,
+		Year:     year,
+		Month:    month,
+		Day:      day,
+		Hour:     hour,
+		Minute:   minute,
+		Second:   second,
+		BuildId:  buildId,
+	}, nil
+}

--- a/util/cstring.go
+++ b/util/cstring.go
@@ -27,3 +27,29 @@ func ReadCString(r io.Reader) (*string, error) {
 	}
 	return &toReturn, nil
 }
+
+func ReadCStringWithSkip(r io.Reader) (*string, error) {
+	var data []byte = make([]byte, 1)
+	var toReturn string
+	for {
+		read, err := r.Read(data)
+		if read == 0 {
+			return nil, fmt.Errorf("string read past the end of r")
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		// Break reading string on null terminator
+		if data[0] == 0 {
+			if len(toReturn) == 0 {
+				continue
+			}
+			break
+		}
+
+		toReturn = toReturn + string(data)
+	}
+	return &toReturn, nil
+}


### PR DESCRIPTION
Adds the ability to extract the game's build info as a json file, and also adds the version information to any gltf file extracted, attached to the Scene as a custom property.

Example:
<img width="581" height="943" alt="image" src="https://github.com/user-attachments/assets/f0124d83-07d2-4b8d-adae-dc8dff01e735" />
