### PR TITLE
Unit and Material preview/export improvements

### DIFF
--- a/cmd/filediver-gui/imutils/imutils.go
+++ b/cmd/filediver-gui/imutils/imutils.go
@@ -138,10 +138,8 @@ func Textcf(color imgui.Vec4, format string, args ...any) {
 }
 
 func CheckboxHeight() float32 {
-	// HACK: This is probably not accurate, but it seems
-	// good enough so it's not noticeable for the user.
 	style := imgui.CurrentStyle()
-	return imgui.FrameHeight() + style.FramePadding().Y + style.ItemSpacing().Y
+	return imgui.FrameHeight() + style.ItemSpacing().Y
 }
 
 func ComboHeight() float32 {

--- a/cmd/filediver-gui/widgets/previews/auto_preview.go
+++ b/cmd/filediver-gui/widgets/previews/auto_preview.go
@@ -363,7 +363,16 @@ func (pv *AutoPreview) Draw(name string) bool {
 	case AutoPreviewEmpty:
 		return false
 	case AutoPreviewUnit:
-		RawUnitPreview(name, pv.previews.rawUnit)
+		RawUnitPreview(name, pv.previews.rawUnit,
+			func(hash stingray.Hash) (name string, ok bool) {
+				name, ok = pv.hashes[hash]
+				return
+			},
+			func(hash stingray.ThinHash) (name string, ok bool) {
+				name, ok = pv.thinhashes[hash]
+				return
+			},
+		)
 	case AutoPreviewTree:
 		SpeedtreePreview(name, pv.previews.speedtree)
 	case AutoPreviewAudio:

--- a/cmd/filediver-gui/widgets/previews/auto_preview.go
+++ b/cmd/filediver-gui/widgets/previews/auto_preview.go
@@ -156,10 +156,6 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 	switch fileID.Type {
 	case stingray.Sum("unit"):
 		pv.activeType = AutoPreviewUnit
-		// if err := loadFiles(stingray.DataMain, stingray.DataGPU); err != nil {
-		// 	pv.err = err
-		// 	return
-		// }
 		if err := pv.previews.rawUnit.LoadUnit(
 			ctx, fileID,
 			pv.getResourceGenerator(true),

--- a/cmd/filediver-gui/widgets/previews/auto_preview.go
+++ b/cmd/filediver-gui/widgets/previews/auto_preview.go
@@ -44,6 +44,7 @@ type AutoPreview struct {
 	activeID   stingray.FileID
 	previews   struct {
 		unit      *UnitPreviewState
+		rawUnit   *RawUnitPreviewState
 		speedtree *SpeedtreePreviewState
 		audio     *WwisePreview
 		video     *BinkPreview
@@ -82,6 +83,10 @@ func NewAutoPreview(otoCtx *oto.Context, audioSampleRate int, hashes map[stingra
 	if err != nil {
 		return nil, err
 	}
+	pv.previews.rawUnit, err = NewRawUnitPreview()
+	if err != nil {
+		return nil, err
+	}
 	pv.previews.audio = NewWwisePreview(otoCtx, audioSampleRate)
 	pv.previews.video = NewBinkPreview(runner)
 	pv.previews.texture = NewImagePreview()
@@ -95,6 +100,7 @@ func NewAutoPreview(otoCtx *oto.Context, audioSampleRate int, hashes map[stingra
 
 func (pv *AutoPreview) Delete() {
 	pv.previews.unit.Delete()
+	pv.previews.rawUnit.Delete()
 	pv.previews.speedtree.Delete()
 	pv.previews.audio.Delete()
 	pv.previews.video.Delete()
@@ -150,14 +156,12 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 	switch fileID.Type {
 	case stingray.Sum("unit"):
 		pv.activeType = AutoPreviewUnit
-		if err := loadFiles(stingray.DataMain, stingray.DataGPU); err != nil {
-			pv.err = err
-			return
-		}
-		if err := pv.previews.unit.LoadUnit(
-			fileID.Name,
-			data[stingray.DataMain],
-			data[stingray.DataGPU],
+		// if err := loadFiles(stingray.DataMain, stingray.DataGPU); err != nil {
+		// 	pv.err = err
+		// 	return
+		// }
+		if err := pv.previews.rawUnit.LoadUnit(
+			ctx, fileID,
 			pv.getResourceGenerator(true),
 			pv.thinhashes,
 		); err != nil {
@@ -359,7 +363,7 @@ func (pv *AutoPreview) Draw(name string) bool {
 	case AutoPreviewEmpty:
 		return false
 	case AutoPreviewUnit:
-		UnitPreview(name, pv.previews.unit)
+		RawUnitPreview(name, pv.previews.rawUnit)
 	case AutoPreviewTree:
 		SpeedtreePreview(name, pv.previews.speedtree)
 	case AutoPreviewAudio:

--- a/cmd/filediver-gui/widgets/previews/material_preview.go
+++ b/cmd/filediver-gui/widgets/previews/material_preview.go
@@ -43,6 +43,7 @@ func (pv *MaterialPreview) LoadMaterial(mat *material.Material, getResource GetR
 
 	clear(pv.settings)
 	pv.settingKeys = nil
+	pv.settingsVisible = true
 	pv.baseMaterial = stingray.Hash{}
 
 	var imgsToLoad []image.Image

--- a/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/AllenDang/cimgui-go/imgui"
-	"github.com/go-gl/gl/v3.2-core/gl"
+	"github.com/go-gl/gl/v4.3-core/gl"
 	"github.com/go-gl/mathgl/mgl32"
 	fnt "github.com/xypwn/filediver/cmd/filediver-gui/fonts"
 	"github.com/xypwn/filediver/cmd/filediver-gui/glutils"

--- a/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
@@ -372,10 +372,11 @@ func (pv *RawUnitPreviewState) LoadUnit(ctx context.Context, fileID stingray.Fil
 				break
 			}
 		}
+		lodname, ok := thinhashes[bones[idx]]
 		lodInfo := rawUnitPreviewLOD{
 			Name:     bones[idx],
 			MeshInfo: meshInfos[idx],
-			Enabled:  true,
+			Enabled:  !ok || !strings.Contains(lodname, "culling"),
 			Matrix:   lodModelMatrix,
 		}
 		object.LODs = append(object.LODs, lodInfo)
@@ -384,6 +385,7 @@ func (pv *RawUnitPreviewState) LoadUnit(ctx context.Context, fileID stingray.Fil
 	pv.objects[fileID.Name.Value] = object
 	pv.fileName = fileID.Name.Value
 
+	pv.numUdims = 0
 	visibilityMasks, err := datalib.ParseVisibilityMasks()
 	if err != nil {
 		return err
@@ -400,6 +402,7 @@ func (pv *RawUnitPreviewState) LoadUnit(ctx context.Context, fileID stingray.Fil
 				name = info.Name.String()
 			}
 			pv.udimNames[info.Index] = name
+			pv.numUdims++
 		}
 	}
 	pv.udimsSelected = pv.udimsShownDefault

--- a/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
@@ -300,14 +300,18 @@ func (pv *RawUnitPreviewState) LoadUnit(ctx context.Context, fileID stingray.Fil
 			return 0
 		case unit.ItemNormal:
 			return 1
+		case unit.ItemTangent:
+			return 2
+		case unit.ItemBinormal:
+			return 3
 		case unit.ItemUVCoords:
-			return 2 + (item.Layer << 4)
-		case unit.ItemBoneIdx:
-			return 3 + (item.Layer << 4)
-		case unit.ItemBoneWeight:
 			return 4 + (item.Layer << 4)
+		case unit.ItemBoneIdx:
+			return 5 + (item.Layer << 4)
+		case unit.ItemBoneWeight:
+			return 6 + (item.Layer << 4)
 		}
-		return 0
+		return 0xffffffff
 	}
 
 	getLayoutType := func(item unit.MeshLayoutItem) uint32 {

--- a/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
@@ -67,7 +67,8 @@ func (obj rawUnitPreviewMeshBuffer) deleteObjects() {
 }
 
 type rawUnitPreviewLOD struct {
-	Name stingray.ThinHash
+	Name    stingray.ThinHash
+	Enabled bool
 	geometry.MeshInfo
 }
 
@@ -202,6 +203,10 @@ func (pv *RawUnitPreviewState) Delete() {
 func (pv *RawUnitPreviewState) LoadUnit(ctx context.Context, fileID stingray.FileID, getResource GetResourceFunc, thinhashes map[stingray.ThinHash]string) error {
 	for i := range pv.udimsSelected {
 		pv.udimsSelected[i] = true
+	}
+	if _, exists := pv.meshBuffers[file.ID().Name.Value]; exists {
+		pv.fileName = file.ID().Name.Value
+		return nil
 	}
 
 	mainData, exists, err := getResource(fileID, stingray.DataMain)
@@ -433,7 +438,7 @@ func (pv *RawUnitPreviewState) getAABBVertices() [8]mgl32.Vec3 {
 	}
 }
 
-func RawUnitPreview(name string, pv *RawUnitPreviewState) {
+func RawUnitPreview(name string, pv *RawUnitPreviewState, lookupHash func(stingray.Hash) (string, bool), lookupThinHash func(stingray.ThinHash) (string, bool)) {
 	if pv.meshBuffers == nil {
 		return
 	}
@@ -448,6 +453,7 @@ func RawUnitPreview(name string, pv *RawUnitPreviewState) {
 	viewSize := imgui.ContentRegionAvail()
 	viewSize.Y -= imutils.CheckboxHeight()
 
+	imgui.SetNextItemAllowOverlap()
 	widgets.GLView(name, pv.fb, viewSize,
 		func() {
 			io := imgui.CurrentIO()
@@ -481,22 +487,25 @@ func RawUnitPreview(name string, pv *RawUnitPreviewState) {
 			gl.UniformMatrix4fv(pv.uniforms["view"], 1, false, &view[0])
 
 			//for file := range pv.lodInfos {
-			//for _, lod := range pv.lodInfos[pv.fileName] {
-			lod := pv.lodInfos[pv.fileName][len(pv.lodInfos[pv.fileName])-1]
-			gl.BindVertexArray(pv.meshBuffers[pv.fileName][lod.MeshLayoutIndex].vao)
-			var indexType uint32
-			switch pv.meshBuffers[pv.fileName][lod.MeshLayoutIndex].idxStride {
-			case 1:
-				indexType = gl.UNSIGNED_BYTE
-			case 2:
-				indexType = gl.UNSIGNED_SHORT
-			case 4:
-				indexType = gl.UNSIGNED_INT
+			for _, lod := range pv.lodInfos[pv.fileName] {
+				if !lod.Enabled {
+					continue
+				}
+				gl.BindVertexArray(pv.meshBuffers[pv.fileName][lod.MeshLayoutIndex].vao)
+				var indexType uint32
+				idxStride := uint32(pv.meshBuffers[pv.fileName][lod.MeshLayoutIndex].idxStride)
+				switch idxStride {
+				case 1:
+					indexType = gl.UNSIGNED_BYTE
+				case 2:
+					indexType = gl.UNSIGNED_SHORT
+				case 4:
+					indexType = gl.UNSIGNED_INT
+				}
+				for _, group := range lod.Groups {
+					gl.DrawElementsBaseVertexWithOffset(gl.TRIANGLES, int32(group.NumIndices), indexType, uintptr(group.IndexOffset*idxStride), int32(group.VertexOffset))
+				}
 			}
-			for _, group := range lod.Groups {
-				gl.DrawElementsBaseVertexWithOffset(gl.TRIANGLES, int32(group.NumIndices), indexType, uintptr(group.IndexOffset), int32(group.VertexOffset))
-			}
-			//}
 			//}
 
 			gl.BindVertexArray(0)
@@ -630,6 +639,29 @@ func RawUnitPreview(name string, pv *RawUnitPreviewState) {
 			}
 		},
 	)
+
+	nextPos := imgui.CursorScreenPos()
+	offsetY := imgui.Vec2{
+		X: 0,
+		Y: float32(len(pv.lodInfos[pv.fileName])) * imutils.CheckboxHeight(),
+	}
+	imgui.SetCursorScreenPos(nextPos.Sub(offsetY))
+	imgui.IndentV(imutils.S(10))
+	for idx := range pv.lodInfos[pv.fileName] {
+		name, ok := lookupThinHash(pv.lodInfos[pv.fileName][idx].Name)
+		if !ok {
+			name = pv.lodInfos[pv.fileName][idx].Name.String()
+		}
+		var vtxCount, idxCount uint32 = 0, 0
+		for _, group := range pv.lodInfos[pv.fileName][idx].Groups {
+			vtxCount += group.NumVertices
+			idxCount += group.NumIndices
+		}
+		imgui.Checkbox(fmt.Sprintf("%v - %v vertices - %v indices", name, vtxCount, idxCount), &pv.lodInfos[pv.fileName][idx].Enabled)
+	}
+	imgui.Unindent()
+
+	imgui.SetCursorScreenPos(nextPos)
 
 	if imgui.Button(fnt.I.Home) {
 		pv.viewRotation = mgl32.Vec2{}

--- a/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
@@ -665,29 +665,6 @@ func RawUnitPreview(name string, pv *RawUnitPreviewState, lookupHash func(stingr
 		},
 	)
 
-	nextPos := imgui.CursorScreenPos()
-	offsetY := imgui.Vec2{
-		X: 0,
-		Y: float32(len(pv.objects[pv.fileName].LODs))*imutils.CheckboxHeight() + imutils.S(10),
-	}
-	imgui.SetCursorScreenPos(nextPos.Sub(offsetY))
-	imgui.IndentV(imutils.S(10))
-	for idx := range pv.objects[pv.fileName].LODs {
-		name, ok := lookupThinHash(pv.objects[pv.fileName].LODs[idx].Name)
-		if !ok {
-			name = pv.objects[pv.fileName].LODs[idx].Name.String()
-		}
-		var vtxCount, idxCount uint32 = 0, 0
-		for _, group := range pv.objects[pv.fileName].LODs[idx].Groups {
-			vtxCount += group.NumVertices
-			idxCount += group.NumIndices
-		}
-		imgui.Checkbox(fmt.Sprintf("%v %v - %v vertices", fnt.I("Deployed_code"), name, vtxCount), &pv.objects[pv.fileName].LODs[idx].Enabled)
-	}
-	imgui.Unindent()
-
-	imgui.SetCursorScreenPos(nextPos)
-
 	if imgui.Button(fnt.I.Home) {
 		pv.viewRotation = mgl32.Vec2{}
 		pv.zoomToFit = true
@@ -734,13 +711,13 @@ func RawUnitPreview(name string, pv *RawUnitPreviewState, lookupHash func(stingr
 	imgui.BeginDisabledV(pv.numUdims <= 1)
 	if imgui.Button("UDims Selection") {
 		imgui.OpenPopupStr("UDims")
-		imgui.SetNextWindowPos(viewPos.Sub(imutils.SVec2(120, 0)))
+		imgui.SetNextWindowPos(viewPos.Sub(imutils.SVec2(240, 0)))
+		imgui.SetNextWindowSize(imgui.NewVec2(imutils.S(240), viewSize.Y))
 	}
 	if pv.numUdims <= 1 {
 		imgui.SetItemTooltip("Mesh has no UDims")
 	}
 	imgui.EndDisabled()
-	imgui.SetNextWindowSize(imutils.SVec2(120, viewSize.Y))
 	if imgui.InternalBeginPopupEx(imgui.IDStr("UDims"), imgui.WindowFlagsNoTitleBar|imgui.WindowFlagsNoSavedSettings) {
 		if imgui.Button("Reset") {
 			pv.udimsSelected = pv.udimsShownDefault
@@ -822,6 +799,35 @@ Drag to toggle multiple items (right-click to cancel)`)
 			}
 		}
 	}
+
+	// LOD selection
+	imgui.SameLine()
+	imgui.BeginDisabledV(len(pv.objects[pv.fileName].LODs) <= 1)
+	if imgui.Button("Mesh Selection") {
+		imgui.OpenPopupStr("LODs")
+		imgui.SetNextWindowPos(viewPos.Sub(imutils.SVec2(240, 0)))
+		//imgui.SetNextWindowSize(imgui.NewVec2(imutils.S(240), viewSize.Y))
+	}
+	if len(pv.objects[pv.fileName].LODs) <= 1 {
+		imgui.SetItemTooltip("Unit has no LODs")
+	}
+	imgui.EndDisabled()
+	if imgui.InternalBeginPopupEx(imgui.IDStr("LODs"), imgui.WindowFlagsNoTitleBar|imgui.WindowFlagsNoSavedSettings) {
+		for idx := range pv.objects[pv.fileName].LODs {
+			name, ok := lookupThinHash(pv.objects[pv.fileName].LODs[idx].Name)
+			if !ok {
+				name = pv.objects[pv.fileName].LODs[idx].Name.String()
+			}
+			var vtxCount, idxCount uint32 = 0, 0
+			for _, group := range pv.objects[pv.fileName].LODs[idx].Groups {
+				vtxCount += group.NumVertices
+				idxCount += group.NumIndices
+			}
+			imgui.Checkbox(fmt.Sprintf("%v %v - %v vertices", fnt.I.DeployedCode, name, vtxCount), &pv.objects[pv.fileName].LODs[idx].Enabled)
+		}
+		imgui.EndPopup()
+	}
+
 	pv.activeUDimListItem = nextActiveUDimListItem
 	pv.hoveredUDimListItem = nextHoveredUDimListItem
 

--- a/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
@@ -124,6 +124,7 @@ type RawUnitPreviewState struct {
 
 	vfov         float32
 	model        mgl32.Mat4
+	modelPos     mgl32.Vec4
 	viewDistance float32
 	viewRotation mgl32.Vec2 // {yaw, pitch}
 
@@ -192,6 +193,7 @@ func NewRawUnitPreview() (*RawUnitPreviewState, error) {
 	pv.aabbColor = [4]float32{0.3, 0.3, 0.8, 0.2}
 	pv.objects = make(map[uint64]rawUnitPreviewObject)
 	pv.model = stingrayToGLCoords
+	pv.modelPos = mgl32.Vec4{0.0, 0.0, 0.0, 1.0}
 
 	return pv, nil
 }
@@ -485,10 +487,22 @@ func RawUnitPreview(name string, pv *RawUnitPreviewState, lookupHash func(stingr
 		func() {
 			io := imgui.CurrentIO()
 
+			_, viewPos, view, projection := pv.computeMVP(viewSize.X / viewSize.Y)
+			invProj := projection.Inv()
+			invModelView := pv.model.Inv().Mul4(view.Inv())
+			cameraPos := pv.model.Inv().Mul4x1(viewPos.Vec4(1.0))
+
 			if imgui.IsItemActive() {
 				md := io.MouseDelta()
-				pv.viewRotation = pv.viewRotation.Add(mgl32.Vec2{md.X, md.Y}.Mul(-0.01))
-				pv.viewRotation[1] = mgl32.Clamp(pv.viewRotation[1], -1.55, 1.55)
+				md4 := mgl32.Vec4{md.X, -md.Y, 0.0, 1.0}
+				if io.KeyShift() && md4.Vec2().LenSqr() > 0 {
+					invMouseDelta := invProj.Mul4x1(md4)
+					positionDelta := invModelView.Mul4x1(invMouseDelta.Vec2().Vec4(0.0, 1.0)).Sub(cameraPos)
+					pv.modelPos = pv.modelPos.Add(positionDelta.Mul(io.DeltaTime()))
+				} else {
+					pv.viewRotation = pv.viewRotation.Add(mgl32.Vec2{md.X, md.Y}.Mul(-0.01))
+					pv.viewRotation[1] = mgl32.Clamp(pv.viewRotation[1], -1.55, 1.55)
+				}
 			}
 			if imgui.IsItemHovered() {
 				scroll := io.MouseWheel()
@@ -517,7 +531,9 @@ func RawUnitPreview(name string, pv *RawUnitPreviewState, lookupHash func(stingr
 				if !lod.Enabled {
 					continue
 				}
-				model := stingrayToGLCoords.Mul4(pv.objects[pv.fileName].Matrix).Mul4(lod.Matrix)
+				position := pv.modelPos.Vec3()
+				translation := mgl32.Translate3D(position.X(), position.Y(), position.Z())
+				model := stingrayToGLCoords.Mul4(pv.objects[pv.fileName].Matrix).Mul4(lod.Matrix).Mul4(translation)
 				gl.UniformMatrix4fv(pv.uniforms["model"], 1, false, &model[0])
 				gl.BindVertexArray(pv.objects[pv.fileName].Buffers[lod.MeshLayoutIndex].vao)
 				var indexType uint32

--- a/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
@@ -277,10 +277,6 @@ func (pv *RawUnitPreviewState) LoadUnit(ctx context.Context, fileID stingray.Fil
 			return fmt.Errorf("%v.unit does not have gpu data", fileID.Name.String())
 		}
 
-		if err != nil {
-			return err
-		}
-
 		for _, unitInfo := range info.MeshInfos {
 			meshInfos = append(meshInfos, geometry.MeshInfo{
 				Groups:          unitInfo.Groups,

--- a/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/raw_unit_preview.go
@@ -1,0 +1,771 @@
+package previews
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+
+	"embed"
+
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/AllenDang/cimgui-go/imgui"
+	"github.com/go-gl/gl/v3.2-core/gl"
+	"github.com/go-gl/mathgl/mgl32"
+	fnt "github.com/xypwn/filediver/cmd/filediver-gui/fonts"
+	"github.com/xypwn/filediver/cmd/filediver-gui/glutils"
+	"github.com/xypwn/filediver/cmd/filediver-gui/imutils"
+	"github.com/xypwn/filediver/cmd/filediver-gui/widgets"
+	datalib "github.com/xypwn/filediver/datalibrary"
+	"github.com/xypwn/filediver/extractor/geometry"
+	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/stingray/unit"
+	geometrygroup "github.com/xypwn/filediver/stingray/unit/geometry_group"
+)
+
+//go:embed shaders/*
+var rawUnitPreviewShaderCode embed.FS
+
+// // stingray coords to OpenGL coords
+// var stingrayToGLCoords = mgl32.Mat4FromRows(
+// 	mgl32.Vec4{1, 0, 0, 0},
+// 	mgl32.Vec4{0, 0, 1, 0},
+// 	mgl32.Vec4{0, -1, 0, 0},
+// 	mgl32.Vec4{0, 0, 0, 1},
+// )
+
+type rawUnitPreviewMeshBuffer struct {
+	vao uint32 // vertex array object
+	ibo uint32 // index buffer object
+	vbo uint32 // vertex buffer object
+
+	numVertices int32
+	numIndices  int32
+	idxStride   int32
+}
+
+func (obj *rawUnitPreviewMeshBuffer) genObjects() {
+	gl.GenVertexArrays(1, &obj.vao)
+	gl.GenBuffers(1, &obj.vbo)
+	gl.GenBuffers(1, &obj.ibo)
+
+	gl.BindVertexArray(obj.vao)
+	defer gl.BindVertexArray(0)
+
+	gl.BindBuffer(gl.ARRAY_BUFFER, obj.vbo)
+	defer gl.BindBuffer(gl.ARRAY_BUFFER, 0)
+
+	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, obj.ibo)
+}
+
+func (obj rawUnitPreviewMeshBuffer) deleteObjects() {
+	gl.DeleteVertexArrays(1, &obj.vao)
+	gl.DeleteBuffers(1, &obj.vbo)
+	gl.DeleteBuffers(1, &obj.ibo)
+}
+
+type rawUnitPreviewLOD struct {
+	Name stingray.ThinHash
+	geometry.MeshInfo
+}
+
+// NOTE(xypwn): We do at most ~10 lookups once per frame,
+// so it should be fine to store this in a string map.
+type rawUnitPreviewUniforms map[string]int32
+
+// Panicks if a name is not a uniform.
+func (uniforms *rawUnitPreviewUniforms) generate(program uint32, names ...string) {
+	if *uniforms == nil {
+		*uniforms = rawUnitPreviewUniforms{}
+	}
+	for _, name := range names {
+		cStr, free := gl.Strs(name + "\x00")
+		loc := gl.GetUniformLocation(program, *cStr)
+		free()
+
+		if loc == -1 {
+			var count int32
+			gl.GetProgramiv(program, gl.ACTIVE_UNIFORMS, &count)
+			buf := make([]uint8, 256)
+
+			for i := range count {
+				var length, size int32
+				var glType uint32
+				gl.GetActiveUniform(program, uint32(i), 256, &length, &size, &glType, &buf[0])
+				fmt.Printf("Uniform #%v Type: %v Name: %v\n", i, glType, string(buf))
+			}
+
+			panic(fmt.Sprintf("Invalid uniform name \"%v\" for program %v", name, program))
+		}
+
+		(*uniforms)[name] = loc
+	}
+}
+
+type RawUnitPreviewState struct {
+	fb *widgets.GLViewState
+
+	meshBuffers map[uint64][]rawUnitPreviewMeshBuffer
+	lodInfos    map[uint64][]rawUnitPreviewLOD
+	vtxArrayIdx uint32
+	fileName    uint64
+	program     uint32
+	uniforms    rawUnitPreviewUniforms
+
+	vfov         float32
+	model        mgl32.Mat4
+	viewDistance float32
+	viewRotation mgl32.Vec2 // {yaw, pitch}
+
+	// Axis-aligned bounding box. Don't forget
+	// to multiply aabb's vertices with aabbMat first!
+	aabb    [2]mgl32.Vec3
+	aabbMat mgl32.Mat4
+
+	maxViewDistance float32
+
+	numUdims          uint32
+	udimsShownDefault [64]bool
+	udimsSelected     [64]bool  // udims persistently selected
+	udimsShown        [64]int32 // udims visually selected 1 (shown) or 0 (hidden)
+	udimNames         [64]string
+
+	// For dragging selection
+	activeUDimListItem  int32
+	hoveredUDimListItem int32
+
+	showAABB        bool
+	aabbColor       [4]float32
+	zoomToFitOnLoad bool
+	zoomToFit       bool // set view distance to fit mesh
+}
+
+func NewRawUnitPreview() (*RawUnitPreviewState, error) {
+	var err error
+
+	pv := &RawUnitPreviewState{}
+
+	pv.fb, err = widgets.NewGLView()
+	if err != nil {
+		return nil, err
+	}
+
+	pv.program, err = glutils.CreateProgramFromSources(rawUnitPreviewShaderCode,
+		"shaders/raw_unit.vert",
+		"shaders/raw_unit.frag",
+	)
+	if err != nil {
+		return nil, err
+	}
+	//pv.uniforms.generate(pv.program, "mvp", "model", "viewPosition")
+	pv.uniforms.generate(pv.program, "projection", "model", "view")
+
+	// setupTexture := func(textureID uint32) {
+	// 	gl.BindTexture(gl.TEXTURE_2D, textureID)
+	// 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT)
+	// 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT)
+	// 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+	// 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+	// 	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
+	// 	gl.BindTexture(gl.TEXTURE_2D, 0)
+	// }
+
+	gl.UseProgram(pv.program)
+	// gl.Uniform1i(pv.uniforms["texAlbedo"], 0)
+	// gl.Uniform1i(pv.uniforms["texNormal"], 1)
+	gl.UseProgram(0)
+
+	pv.vfov = mgl32.DegToRad(60)
+	pv.viewDistance = 25
+	pv.maxViewDistance = 100
+
+	pv.aabbColor = [4]float32{0.3, 0.3, 0.8, 0.2}
+	pv.meshBuffers = make(map[uint64][]rawUnitPreviewMeshBuffer)
+	pv.lodInfos = make(map[uint64][]rawUnitPreviewLOD)
+	pv.model = stingrayToGLCoords
+
+	return pv, nil
+}
+
+func (pv *RawUnitPreviewState) Delete() {
+	pv.fb.Delete()
+	gl.DeleteProgram(pv.program)
+	for model := range pv.meshBuffers {
+		for _, mesh := range pv.meshBuffers[model] {
+			mesh.deleteObjects()
+		}
+	}
+}
+
+func (pv *RawUnitPreviewState) LoadUnit(ctx context.Context, fileID stingray.FileID, getResource GetResourceFunc, thinhashes map[stingray.ThinHash]string) error {
+	for i := range pv.udimsSelected {
+		pv.udimsSelected[i] = true
+	}
+
+	mainData, exists, err := getResource(fileID, stingray.DataMain)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("file %v.unit does not exist", fileID.Name.String())
+	}
+	mainR := bytes.NewReader(mainData)
+
+	info, err := unit.LoadInfo(mainR)
+	if err != nil {
+		return err
+	}
+
+	var meshLayouts []unit.MeshLayout
+	var gpuData []byte
+
+	var meshInfos []geometry.MeshInfo
+	var bones []stingray.ThinHash
+	if info.GeometryGroup.Value != 0x0 {
+		geoId := stingray.FileID{
+			Name: info.GeometryGroup,
+			Type: stingray.Sum("geometry_group"),
+		}
+		geoMain, exists, err := getResource(geoId, stingray.DataMain)
+		if !exists {
+			return fmt.Errorf("%v.geometry_group was not found", info.GeometryGroup.String())
+		}
+		if err != nil {
+			return err
+		}
+
+		geoGroup, err := geometrygroup.LoadGeometryGroup(bytes.NewReader(geoMain))
+		if err != nil {
+			return err
+		}
+
+		geoInfo, ok := geoGroup.MeshInfos[fileID.Name]
+		if !ok {
+			return fmt.Errorf("%v.geometry_group did not contain %v.unit?", info.GeometryGroup.String(), fileID.Name.String())
+		}
+		gpuData, exists, err = getResource(geoId, stingray.DataGPU)
+		meshLayouts = geoGroup.MeshLayouts
+		for _, header := range geoInfo.MeshHeaders {
+			meshInfos = append(meshInfos, geometry.MeshInfo{
+				Groups:          header.Groups,
+				Materials:       header.Materials,
+				MeshLayoutIndex: header.MeshLayoutIndex,
+			})
+		}
+		bones = geoInfo.Bones
+	} else {
+		meshLayouts = info.MeshLayouts
+		bones = info.GroupBones
+		gpuData, exists, err = getResource(fileID, stingray.DataGPU)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("%v.unit does not have gpu data", fileID.Name.String())
+		}
+
+		if err != nil {
+			return err
+		}
+
+		for _, unitInfo := range info.MeshInfos {
+			meshInfos = append(meshInfos, geometry.MeshInfo{
+				Groups:          unitInfo.Groups,
+				Materials:       unitInfo.Materials,
+				MeshLayoutIndex: uint32(unitInfo.Header.LayoutIdx),
+			})
+		}
+	}
+
+	if len(bones) != len(meshInfos) {
+		return fmt.Errorf("Number of LOD names != number of LOD infos for file %v.unit!", fileID.Name.String())
+	}
+
+	getLayoutIdx := func(item unit.MeshLayoutItem) uint32 {
+		switch item.Type {
+		case unit.ItemPosition:
+			return 0
+		case unit.ItemNormal:
+			return 1
+		case unit.ItemUVCoords:
+			return 2 + (item.Layer << 4)
+		case unit.ItemBoneIdx:
+			return 3 + (item.Layer << 4)
+		case unit.ItemBoneWeight:
+			return 4 + (item.Layer << 4)
+		}
+		return 0
+	}
+
+	getLayoutType := func(item unit.MeshLayoutItem) uint32 {
+		switch item.Format {
+		case unit.FormatF32, unit.FormatVec2F, unit.FormatVec3F, unit.FormatVec4F:
+			return gl.FLOAT
+		case unit.FormatF16, unit.FormatVec2F16, unit.FormatVec3F16, unit.FormatVec4F16:
+			return gl.HALF_FLOAT
+		case unit.FormatU32, unit.FormatVec2U32, unit.FormatVec3U32, unit.FormatVec4U32:
+			return gl.UNSIGNED_INT
+		case unit.FormatRGBA8:
+			return gl.UNSIGNED_BYTE
+		case unit.FormatS8, unit.FormatVec2S8, unit.FormatVec3S8, unit.FormatVec4S8:
+			return gl.BYTE
+		case unit.FormatVec4R10G10B10A2_TYPELESS, unit.FormatVec4R10G10B10A2_UNORM:
+			return gl.UNSIGNED_INT
+		}
+		return 0
+	}
+
+	for _, layout := range meshLayouts {
+		meshBuffer := rawUnitPreviewMeshBuffer{}
+		meshBuffer.genObjects()
+		meshBuffer.numVertices = int32(layout.NumVertices)
+		meshBuffer.numIndices = int32(layout.NumIndices)
+		meshBuffer.idxStride = int32(layout.IndicesSize / layout.NumIndices)
+
+		gl.BindVertexArray(meshBuffer.vao)
+		gl.BindBuffer(gl.ARRAY_BUFFER, meshBuffer.vbo)
+		gl.BufferData(gl.ARRAY_BUFFER, int(layout.PositionsSize), gl.Ptr(&gpuData[layout.VertexOffset]), gl.STATIC_DRAW)
+		gl.BufferData(gl.ELEMENT_ARRAY_BUFFER, int(layout.IndicesSize), gl.Ptr(&gpuData[layout.IndexOffset]), gl.STATIC_DRAW)
+
+		var offset uintptr = 0
+		for idx := range layout.NumItems {
+			layoutIdx := getLayoutIdx(layout.Items[idx])
+			gl.VertexAttribPointerWithOffset(
+				layoutIdx,
+				int32(layout.Items[idx].Format.Type().Components()),
+				getLayoutType(layout.Items[idx]),
+				false,
+				int32(layout.VertexStride),
+				offset,
+			)
+			gl.EnableVertexAttribArray(layoutIdx)
+			offset += uintptr(layout.Items[idx].Format.Size())
+		}
+		pv.meshBuffers[fileID.Name.Value] = append(pv.meshBuffers[fileID.Name.Value], meshBuffer)
+	}
+
+	for idx := range bones {
+		lodInfo := rawUnitPreviewLOD{
+			Name:     bones[idx],
+			MeshInfo: meshInfos[idx],
+		}
+		pv.lodInfos[fileID.Name.Value] = append(pv.lodInfos[fileID.Name.Value], lodInfo)
+	}
+
+	visibilityMasks, err := datalib.ParseVisibilityMasks()
+	if err != nil {
+		return err
+	}
+	if visibilityMask, ok := visibilityMasks[fileID.Name]; ok {
+		for _, info := range visibilityMask.MaskInfos {
+			if int(info.Index) >= len(pv.udimsShownDefault) {
+				// No support for udims with index > 64 at the moment
+				continue
+			}
+			pv.udimsShownDefault[info.Index] = info.StartHidden == 0
+			name, ok := thinhashes[info.Name]
+			if !ok {
+				name = info.Name.String()
+			}
+			pv.udimNames[info.Index] = name
+		}
+	}
+	pv.udimsSelected = pv.udimsShownDefault
+
+	pv.fileName = fileID.Name.Value
+	return nil
+}
+
+func (pv *RawUnitPreviewState) computeMVP(aspectRatio float32) (
+	normal mgl32.Mat3,
+	viewPosition mgl32.Vec3,
+	view mgl32.Mat4,
+	projection mgl32.Mat4,
+) {
+	normal = pv.model.Inv().Transpose().Mat3()
+	{
+		mat := mgl32.Ident3()
+		mat = mat.Mul3(mgl32.Rotate3DY(pv.viewRotation[0]))
+		mat = mat.Mul3(mgl32.Rotate3DX(pv.viewRotation[1]))
+		viewPosition = mat.Mul3x1(mgl32.Vec3{0, 0, pv.viewDistance})
+	}
+	view = mgl32.LookAt(
+		viewPosition[0], viewPosition[1], viewPosition[2],
+		0, 0, 0,
+		0, 1, 0,
+	)
+	projection = mgl32.Perspective(
+		pv.vfov,
+		aspectRatio,
+		0.001,
+		32768,
+	)
+	return
+}
+
+// var aabbIndices = [12 * 3]uint32{
+// 	1, 2, 0,
+// 	1, 3, 2,
+// 	0, 6, 4,
+// 	0, 2, 6,
+// 	4, 7, 5,
+// 	4, 6, 7,
+// 	5, 3, 1,
+// 	5, 7, 3,
+// 	2, 3, 7,
+// 	2, 7, 6,
+// 	0, 4, 5,
+// 	0, 5, 1,
+// }
+
+func (pv *RawUnitPreviewState) getAABBVertices() [8]mgl32.Vec3 {
+	return [8]mgl32.Vec3{
+		{pv.aabb[0][0], pv.aabb[0][1], pv.aabb[0][2]},
+		{pv.aabb[0][0], pv.aabb[0][1], pv.aabb[1][2]},
+		{pv.aabb[0][0], pv.aabb[1][1], pv.aabb[0][2]},
+		{pv.aabb[0][0], pv.aabb[1][1], pv.aabb[1][2]},
+		{pv.aabb[1][0], pv.aabb[0][1], pv.aabb[0][2]},
+		{pv.aabb[1][0], pv.aabb[0][1], pv.aabb[1][2]},
+		{pv.aabb[1][0], pv.aabb[1][1], pv.aabb[0][2]},
+		{pv.aabb[1][0], pv.aabb[1][1], pv.aabb[1][2]},
+	}
+}
+
+func RawUnitPreview(name string, pv *RawUnitPreviewState) {
+	if pv.meshBuffers == nil {
+		return
+	}
+	if pv.meshBuffers[pv.fileName][pv.vtxArrayIdx].numIndices == 0 {
+		return
+	}
+
+	imgui.PushIDStr(name)
+	defer imgui.PopID()
+
+	viewPos := imgui.CursorScreenPos()
+	viewSize := imgui.ContentRegionAvail()
+	viewSize.Y -= imutils.CheckboxHeight()
+
+	widgets.GLView(name, pv.fb, viewSize,
+		func() {
+			io := imgui.CurrentIO()
+
+			if imgui.IsItemActive() {
+				md := io.MouseDelta()
+				pv.viewRotation = pv.viewRotation.Add(mgl32.Vec2{md.X, md.Y}.Mul(-0.01))
+				pv.viewRotation[1] = mgl32.Clamp(pv.viewRotation[1], -1.55, 1.55)
+			}
+			if imgui.IsItemHovered() {
+				scroll := io.MouseWheel()
+				pv.viewDistance -= 0.1 * pv.viewDistance * scroll
+			}
+			pv.viewDistance = mgl32.Clamp(
+				pv.viewDistance,
+				0.001,
+				pv.maxViewDistance,
+			)
+		},
+		func(pos, size imgui.Vec2) {
+			gl.ClearColor(0.2, 0.2, 0.2, 1)
+			gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
+
+			_, _, view, projection := pv.computeMVP(size.X / size.Y)
+
+			// Draw object
+			gl.Enable(gl.DEPTH_TEST)
+			gl.UseProgram(pv.program)
+			gl.UniformMatrix4fv(pv.uniforms["projection"], 1, false, &projection[0])
+			gl.UniformMatrix4fv(pv.uniforms["model"], 1, false, &pv.model[0])
+			gl.UniformMatrix4fv(pv.uniforms["view"], 1, false, &view[0])
+
+			//for file := range pv.lodInfos {
+			//for _, lod := range pv.lodInfos[pv.fileName] {
+			lod := pv.lodInfos[pv.fileName][len(pv.lodInfos[pv.fileName])-1]
+			gl.BindVertexArray(pv.meshBuffers[pv.fileName][lod.MeshLayoutIndex].vao)
+			var indexType uint32
+			switch pv.meshBuffers[pv.fileName][lod.MeshLayoutIndex].idxStride {
+			case 1:
+				indexType = gl.UNSIGNED_BYTE
+			case 2:
+				indexType = gl.UNSIGNED_SHORT
+			case 4:
+				indexType = gl.UNSIGNED_INT
+			}
+			for _, group := range lod.Groups {
+				gl.DrawElementsBaseVertexWithOffset(gl.TRIANGLES, int32(group.NumIndices), indexType, uintptr(group.IndexOffset), int32(group.VertexOffset))
+			}
+			//}
+			//}
+
+			gl.BindVertexArray(0)
+			gl.UseProgram(0)
+			gl.PolygonMode(gl.FRONT_AND_BACK, gl.FILL)
+
+			if pv.zoomToFit && false {
+				pv.viewDistance = pv.maxViewDistance
+
+				_, viewPosition, view, projection := pv.computeMVP(size.X / size.Y)
+
+				fitVertexCamDistDelta := func(vertex mgl32.Vec3) float32 {
+					v := vertex.Vec4(1.0)
+					v = pv.model.Mul4x1(v)
+
+					// NOTE(xypwn): I think the projections are still off, but
+					// this whole code seems to at least do what I wanted it
+					// to now.
+					projV := projection.Mul4x1(view.Mul4x1(v))
+					projV = projV.Mul(1 / projV.W())
+
+					// Component with maximum distance from screen center
+					maxDist := max(mgl32.Abs(projV.X()), mgl32.Abs(projV.Y()))
+
+					// Calculate orthogonal distance from camera to selected vertex
+					var od float32
+					{
+						viewDir := mgl32.Vec3{}.Sub(viewPosition).Normalize()
+						vert := v
+						vert = vert.Mul(1 / vert.W())
+						camToVert := vert.Vec3().Sub(viewPosition)
+						od = viewDir.Dot(camToVert)
+					}
+
+					// Fit model to screen
+					return od * (maxDist - 1)
+				}
+
+				// NOTE(xypwn): I used to use the AABB vertices for this, but they would often be
+				// wrong. Using all of the mesh positions instead takes no more than ~10ms on
+				// all of the models I've tried.
+				maxCamDistDelta := float32(-math.MaxFloat32)
+				for _, vert := range pv.aabb {
+					maxCamDistDelta = max(maxCamDistDelta,
+						fitVertexCamDistDelta(vert))
+				}
+				pv.viewDistance += maxCamDistDelta
+				pv.viewDistance *= 1.02
+
+				pv.zoomToFit = false
+			}
+		},
+		func(pos, size imgui.Vec2) {
+			dl := imgui.WindowDrawList()
+
+			// Scale indicator
+			{
+				// Screen size in world here refers to how large the screen
+				// content rectangle would be if it intersected
+				// the origin.
+				// tan(vfov/2) = screenHeightInWorld/camDist
+				screenHeightInWorld := float32(math.Tan(float64(pv.vfov/2)) * float64(pv.viewDistance))
+				screenWidthInWorld := screenHeightInWorld / size.Y * size.X
+				indicatorWidthInWorld := screenWidthInWorld / 2
+				{
+					order := float32(
+						math.Pow(
+							10,
+							math.Floor(math.Log10(float64(indicatorWidthInWorld)))-1,
+						),
+					)
+					indicatorWidthInWorld = order * float32(math.Floor(float64(indicatorWidthInWorld/order)))
+				}
+				indicatorColor := imgui.ColorU32Col(imgui.ColText)
+
+				indicatorWidth := size.X * indicatorWidthInWorld / screenWidthInWorld
+				indicatorPos := pos.Add(imutils.SVec2(10, 10))
+				dl.AddRectFilled(
+					indicatorPos.Add(imutils.SVec2(0, 0)),
+					indicatorPos.Add(imutils.SVec2(2, 10)),
+					indicatorColor,
+				)
+				dl.AddRectFilled(
+					indicatorPos.Add(imutils.SVec2(0, 4)),
+					indicatorPos.Add(imgui.NewVec2(indicatorWidth, 0).Add(imutils.SVec2(0, 6))),
+					indicatorColor,
+				)
+				dl.AddRectFilled(
+					indicatorPos.Add(imgui.NewVec2(indicatorWidth, 0).Add(imutils.SVec2(-2, 0))),
+					indicatorPos.Add(imgui.NewVec2(indicatorWidth, 0).Add(imutils.SVec2(0, 10))),
+					indicatorColor,
+				)
+
+				var dimPrefix string
+				var dim float32
+				if indicatorWidthInWorld >= 1e3 {
+					dimPrefix = "k"
+					dim = 1e3
+				} else if indicatorWidthInWorld >= 1 {
+					dimPrefix = ""
+					dim = 1
+				} else if indicatorWidthInWorld >= 1e-2 {
+					dimPrefix = "c"
+					dim = 1e-2
+				} else if indicatorWidthInWorld >= 1e-3 {
+					dimPrefix = "m"
+					dim = 1e-3
+				} else {
+					dimPrefix = "µ"
+					dim = 1e-6
+				}
+				text := fmt.Sprintf(
+					"%v%vm",
+					strings.TrimRight(strings.TrimRight(
+						fmt.Sprintf("%.3f", indicatorWidthInWorld/dim),
+						"0"), "."),
+					dimPrefix,
+				)
+				textSize := imgui.CalcTextSize(text)
+				textPos := indicatorPos.Add(imgui.NewVec2(indicatorWidth/2-textSize.X/2, 0)).Add(imutils.SVec2(0, 12))
+				dl.AddRectFilled(
+					textPos.Add(imutils.SVec2(-4, 0)),
+					textPos.Add(textSize).Add(imutils.SVec2(4, 0)),
+					imgui.ColorU32Vec4(imgui.NewVec4(0, 0, 0, 0.5)),
+				)
+				dl.AddTextVec2(
+					textPos,
+					indicatorColor,
+					text,
+				)
+			}
+		},
+	)
+
+	if imgui.Button(fnt.I.Home) {
+		pv.viewRotation = mgl32.Vec2{}
+		pv.zoomToFit = true
+	}
+	imgui.SetItemTooltip("Reset view")
+	imgui.SameLine()
+	if imgui.Button(fnt.I.DataObject) {
+		imgui.OpenPopupStr("Debug info")
+	}
+	imgui.SetItemTooltip("Mesh debug info...")
+	if imgui.BeginPopup("Debug info") {
+		imgui.TextUnformatted("Mesh info")
+		imgui.Indent()
+		imutils.Textf("Indices: %v", pv.meshBuffers[pv.fileName][pv.vtxArrayIdx].numIndices)
+		imutils.Textf("Vertices: %v", pv.meshBuffers[pv.fileName][pv.vtxArrayIdx].numVertices)
+		imutils.Textf("Triangles: %v", pv.meshBuffers[pv.fileName][pv.vtxArrayIdx].numIndices/3)
+		imgui.Unindent()
+
+		imgui.Separator()
+
+		const colorPickerFlags = imgui.ColorEditFlagsNoInputs | imgui.ColorEditFlagsAlphaBar | imgui.ColorEditFlagsNoLabel
+		imgui.TextUnformatted("Display")
+		imgui.Indent()
+
+		imgui.Checkbox("Bounding box", &pv.showAABB)
+		imgui.SameLine()
+		imgui.TextUnformatted(fnt.I.Warning)
+		imgui.SetItemTooltip("Bounding boxes are known to sometimes be wrong")
+		imgui.SameLineV(imutils.S(170), -1)
+		imgui.ColorEdit4V("Bounding box color", &pv.aabbColor, colorPickerFlags)
+
+		imgui.Unindent()
+
+		imgui.EndPopup()
+	}
+	imgui.SameLine()
+	if imgui.Checkbox("Auto-zoom on load", &pv.zoomToFitOnLoad) && pv.zoomToFitOnLoad {
+		pv.zoomToFit = true
+	}
+	imgui.SameLine()
+	// UDim selection
+	nextActiveUDimListItem := int32(-1)
+	nextHoveredUDimListItem := int32(-1)
+	imgui.BeginDisabledV(pv.numUdims <= 1)
+	if imgui.Button("UDims Selection") {
+		imgui.OpenPopupStr("UDims")
+		imgui.SetNextWindowPos(viewPos.Sub(imutils.SVec2(120, 0)))
+	}
+	if pv.numUdims <= 1 {
+		imgui.SetItemTooltip("Mesh has no UDims")
+	}
+	imgui.EndDisabled()
+	imgui.SetNextWindowSize(imutils.SVec2(120, viewSize.Y))
+	if imgui.InternalBeginPopupEx(imgui.IDStr("UDims"), imgui.WindowFlagsNoTitleBar|imgui.WindowFlagsNoSavedSettings) {
+		if imgui.Button("Reset") {
+			pv.udimsSelected = pv.udimsShownDefault
+		}
+		imgui.Separator()
+		imgui.PushStyleVarVec2(imgui.StyleVarItemSpacing,
+			imgui.NewVec2(imgui.CurrentStyle().ItemSpacing().X, 0))
+		dragging := pv.activeUDimListItem != -1 && pv.hoveredUDimListItem != -1
+		var draggingMin, draggingMax int32
+		if dragging {
+			draggingMin = min(pv.activeUDimListItem, pv.hoveredUDimListItem)
+			draggingMax = max(pv.activeUDimListItem, pv.hoveredUDimListItem)
+		}
+		var draggingMinPos, draggingMaxPos imgui.Vec2
+		for i := range int32(pv.numUdims) {
+			selected := pv.udimsSelected[i]
+			if dragging {
+				if i >= draggingMin && i <= draggingMax {
+					selected = !selected
+				}
+				if imgui.IsMouseClickedBool(imgui.MouseButtonRight) {
+					imgui.CurrentContext().SetActiveId(0)
+				}
+			}
+			if selected {
+				pv.udimsShown[i] = 1
+			} else {
+				pv.udimsShown[i] = 0
+			}
+			if imgui.IsMouseReleased(imgui.MouseButtonLeft) {
+				pv.udimsSelected[i] = selected
+			}
+			var icon string
+			if selected {
+				icon = fnt.I.Visibility
+			} else {
+				icon = fnt.I.VisibilityOff
+			}
+			imgui.PushIDInt(i)
+			pos := imgui.CursorScreenPos()
+			size := imgui.NewVec2(imgui.ContentRegionAvail().X, imgui.FontSize())
+			if dragging {
+				if i == draggingMin {
+					draggingMinPos = pos
+				}
+				if i == draggingMax {
+					draggingMaxPos = pos.Add(size)
+				}
+			}
+			if selected {
+				imgui.WindowDrawList().AddRectFilled(pos, pos.Add(size), imgui.ColorU32Col(imgui.ColButton))
+			}
+			imutils.Textf(fmt.Sprintf("%s %02d: %s", icon, i, cmp.Or(pv.udimNames[i], "unknown")))
+			imgui.SetCursorScreenPos(pos)
+			imgui.SetNextItemAllowOverlap()
+			imgui.InvisibleButton("btn", size)
+			if imgui.IsItemActive() {
+				nextActiveUDimListItem = i
+			}
+			hovered := imgui.ItemStatusFlags(imgui.CurrentContext().LastItemData().CData.StatusFlags)&imgui.ItemStatusFlagsHoveredRect != 0
+			if hovered {
+				nextHoveredUDimListItem = i
+			}
+			imgui.SetItemTooltip(`Click to toggle item visibility
+Drag to toggle multiple items (right-click to cancel)`)
+			imgui.PopID()
+		}
+		imgui.PopStyleVar()
+		if dragging {
+			imgui.WindowDrawList().AddRectV(draggingMinPos, draggingMaxPos, imgui.ColorU32Col(imgui.ColButtonActive), 0, 0, 2)
+		}
+		imgui.EndPopup()
+	} else {
+		for i := range pv.udimsShown {
+			if pv.udimsSelected[i] {
+				pv.udimsShown[i] = 1
+			} else {
+				pv.udimsShown[i] = 0
+			}
+		}
+	}
+	pv.activeUDimListItem = nextActiveUDimListItem
+	pv.hoveredUDimListItem = nextHoveredUDimListItem
+
+}

--- a/cmd/filediver-gui/widgets/previews/shaders/raw_unit.frag
+++ b/cmd/filediver-gui/widgets/previews/shaders/raw_unit.frag
@@ -1,0 +1,10 @@
+#version 330 core
+
+out vec4 fragColor;
+
+in vec3 fragPosition;
+in vec2 fragUV;
+
+void main() {
+    fragColor = vec4(fragUV, 1.0, 1.0);
+}

--- a/cmd/filediver-gui/widgets/previews/shaders/raw_unit.vert
+++ b/cmd/filediver-gui/widgets/previews/shaders/raw_unit.vert
@@ -1,0 +1,17 @@
+#version 330 core
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 2) in vec2 inUV;
+
+out vec3 fragPosition;
+out vec2 fragUV;
+
+uniform mat4 projection;
+uniform mat4 model;
+uniform mat4 view;
+
+void main() {
+    gl_Position = projection * view * model * vec4(inPosition, 1.0);
+    fragPosition = vec3(model * vec4(inPosition, 1.0));
+    fragUV = inUV;
+}

--- a/cmd/tools/dxbc-converter/main.go
+++ b/cmd/tools/dxbc-converter/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+
+	"github.com/hellflame/argparse"
+	"github.com/jwalton/go-supportscolor"
+	"github.com/xypwn/filediver/app"
+	"github.com/xypwn/filediver/stingray/unit/material/d3d"
+)
+
+func main() {
+	prt := app.NewConsolePrinter(
+		supportscolor.Stderr().SupportsColor,
+		os.Stderr,
+		os.Stderr,
+	)
+
+	parser := argparse.NewParser("dxbc-converter", "DXBC to GLSL translator for Filediver", &argparse.ParserConfig{
+		DisableHelp:            false,
+		DisableDefaultShowHelp: true,
+		WithHint:               true,
+	})
+
+	input := parser.String("i", "input", &argparse.Option{
+		Help: "Path to a dxbc file",
+	})
+	output := parser.String("o", "output", &argparse.Option{
+		Help: "Path to write the output glsl file",
+	})
+
+	if err := parser.Parse(nil); err != nil {
+		prt.Fatalf("%v", err)
+	}
+
+	f, err := os.Open(*input)
+	if err != nil {
+		prt.Fatalf("%v", err)
+	}
+	defer f.Close()
+
+	prt.Infof("Parsing %v...", *input)
+	dxbc, err := d3d.ParseDXBC(f)
+	if err != nil {
+		prt.Fatalf("ParseDXBC: %v", err)
+	}
+
+	out, err := os.Create(*output)
+	if err != nil {
+		prt.Fatalf("%v", err)
+	}
+	defer out.Close()
+
+	prt.Infof("Writing %v...", *output)
+	for _, opcode := range dxbc.ShaderCode.Opcodes {
+		out.WriteString(opcode.ToGLSL())
+	}
+	prt.Infof("Done.")
+}

--- a/cmd/tools/dxbc-converter/main.go
+++ b/cmd/tools/dxbc-converter/main.go
@@ -52,8 +52,6 @@ func main() {
 	defer out.Close()
 
 	prt.Infof("Writing %v...", *output)
-	for _, opcode := range dxbc.ShaderCode.Opcodes {
-		out.WriteString(opcode.ToGLSL())
-	}
+	out.WriteString(dxbc.ToGLSL())
 	prt.Infof("Done.")
 }

--- a/cmd/tools/dxbc-dumper/main.go
+++ b/cmd/tools/dxbc-dumper/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/hellflame/argparse"
+	"github.com/jwalton/go-supportscolor"
+	"github.com/xypwn/filediver/app"
+	"github.com/xypwn/filediver/stingray/unit/material/d3d"
+)
+
+func main() {
+	prt := app.NewConsolePrinter(
+		supportscolor.Stderr().SupportsColor,
+		os.Stderr,
+		os.Stderr,
+	)
+
+	parser := argparse.NewParser("dxbc-dumper", "DXBC dumper for Filediver", &argparse.ParserConfig{
+		DisableHelp:            false,
+		DisableDefaultShowHelp: true,
+		WithHint:               true,
+	})
+
+	input := parser.String("i", "input", &argparse.Option{
+		Help: "Path to a material.gpu file",
+	})
+	output := parser.String("o", "output", &argparse.Option{
+		Help: "Folder path to write the output dxbc/glsl file(s)",
+	})
+	glsl := parser.Flag("g", "glsl", &argparse.Option{
+		Help: "Write GLSL files rather than DXBC files",
+	})
+
+	if err := parser.Parse(nil); err != nil {
+		prt.Fatalf("%v", err)
+	}
+
+	f, err := os.Open(*input)
+	if err != nil {
+		prt.Fatalf("%v", err)
+	}
+	defer f.Close()
+
+	prt.Infof("Parsing %v...", *input)
+	data, err := io.ReadAll(f)
+	if err != nil {
+		prt.Fatalf("%v", err)
+	}
+	var offset int = 0
+	fileCountMap := make(map[d3d.ShaderProgramType]int)
+	suffix := "dxbc"
+	if *glsl {
+		suffix = "glsl"
+	}
+	for true {
+		if offset >= len(data) {
+			break
+		}
+		idx := bytes.Index(data[offset:], d3d.MAGIC[:])
+		if idx < 0 {
+			break
+		}
+		dxbc, err := d3d.ParseDXBC(bytes.NewReader(data[offset+idx:]))
+		if err != nil {
+			prt.Errorf("ParseDXBC: %v (%#08x)", err, idx)
+			idx = idx + 4
+			break
+		}
+
+		if _, ok := fileCountMap[dxbc.ShaderCode.ProgramType]; !ok {
+			fileCountMap[dxbc.ShaderCode.ProgramType] = 0
+		}
+		filename := *output + string(os.PathSeparator) + fmt.Sprintf("%v.%v", fileCountMap[dxbc.ShaderCode.ProgramType], suffix)
+
+		switch dxbc.ShaderCode.ProgramType {
+		case d3d.PIXEL_SHADER:
+			filename += ".frag"
+		case d3d.VERTEX_SHADER:
+			filename += ".vert"
+		case d3d.GEOMETRY_SHADER:
+			filename += ".geom"
+		case d3d.HULL_SHADER:
+			filename += ".tesc"
+		case d3d.DOMAIN_SHADER:
+			filename += ".tese"
+		case d3d.COMPUTE_SHADER:
+			filename += ".comp"
+		}
+
+		prt.Infof("Offset %#08x", offset+idx)
+		prt.Infof("Version %v.%v", dxbc.ShaderCode.Version.Major, dxbc.ShaderCode.Version.Minor)
+		prt.Infof("Program type %v", dxbc.ShaderCode.ProgramType)
+
+		out, err := os.Create(filename)
+		if os.IsNotExist(err) {
+			err = os.Mkdir(*output, os.ModeDir|os.ModePerm)
+			if err == nil {
+				out, err = os.Create(filename)
+			}
+		}
+		if err != nil {
+			prt.Fatalf("%v", err)
+		}
+		defer out.Close()
+
+		prt.Infof("Writing %v...", filename)
+		if *glsl {
+			out.WriteString(dxbc.ToGLSL())
+		} else {
+			out.Write(data[offset+idx : offset+idx+int(dxbc.Size)])
+		}
+		offset = offset + idx + int(dxbc.Size)
+		fileCountMap[dxbc.ShaderCode.ProgramType]++
+		prt.Infof("")
+	}
+
+	prt.Infof("Done.")
+}

--- a/cmd/tools/dxbc-dumper/main.go
+++ b/cmd/tools/dxbc-dumper/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,10 @@ import (
 	"github.com/hellflame/argparse"
 	"github.com/jwalton/go-supportscolor"
 	"github.com/xypwn/filediver/app"
+	"github.com/xypwn/filediver/hashes"
+	"github.com/xypwn/filediver/stingray"
 	"github.com/xypwn/filediver/stingray/unit/material/d3d"
+	d3dops "github.com/xypwn/filediver/stingray/unit/material/d3d/opcodes"
 )
 
 func main() {
@@ -24,6 +28,22 @@ func main() {
 		DisableDefaultShowHelp: true,
 		WithHint:               true,
 	})
+
+	var knownThinHashes []string
+	knownThinHashes = append(knownThinHashes, hashes.ParseHashes(hashes.ThinHashes)...)
+
+	thinHashesMap := make(map[stingray.ThinHash]string)
+	for _, h := range knownThinHashes {
+		thinHashesMap[stingray.Sum(h).Thin()] = h
+	}
+
+	lookupThinHash := func(hash stingray.ThinHash) string {
+		val, ok := thinHashesMap[hash]
+		if ok {
+			return val
+		}
+		return hash.String()
+	}
 
 	input := parser.String("i", "input", &argparse.Option{
 		Help: "Path to a material.gpu file",
@@ -51,7 +71,7 @@ func main() {
 		prt.Fatalf("%v", err)
 	}
 	var offset int = 0
-	fileCountMap := make(map[d3d.ShaderProgramType]int)
+	fileCountMap := make(map[d3dops.ShaderProgramType]int)
 	suffix := "dxbc"
 	if *glsl {
 		suffix = "glsl"
@@ -64,7 +84,8 @@ func main() {
 		if idx < 0 {
 			break
 		}
-		dxbc, err := d3d.ParseDXBC(bytes.NewReader(data[offset+idx:]))
+		reader := bytes.NewReader(data[offset+idx:])
+		dxbc, err := d3d.ParseDXBC(reader)
 		if err != nil {
 			prt.Errorf("ParseDXBC: %v (%#08x)", err, idx)
 			idx = idx + 4
@@ -77,18 +98,24 @@ func main() {
 		filename := *output + string(os.PathSeparator) + fmt.Sprintf("%v.%v", fileCountMap[dxbc.ShaderCode.ProgramType], suffix)
 
 		switch dxbc.ShaderCode.ProgramType {
-		case d3d.PIXEL_SHADER:
+		case d3dops.PIXEL_SHADER:
 			filename += ".frag"
-		case d3d.VERTEX_SHADER:
+		case d3dops.VERTEX_SHADER:
 			filename += ".vert"
-		case d3d.GEOMETRY_SHADER:
+		case d3dops.GEOMETRY_SHADER:
 			filename += ".geom"
-		case d3d.HULL_SHADER:
+		case d3dops.HULL_SHADER:
 			filename += ".tesc"
-		case d3d.DOMAIN_SHADER:
+		case d3dops.DOMAIN_SHADER:
 			filename += ".tese"
-		case d3d.COMPUTE_SHADER:
+		case d3dops.COMPUTE_SHADER:
 			filename += ".comp"
+		}
+
+		var thinHash stingray.ThinHash
+		err = binary.Read(reader, binary.LittleEndian, &thinHash)
+		if err == nil {
+			fmt.Printf("%v - %v - %v\n", lookupThinHash(thinHash), filename, dxbc.ShaderCode.ProgramType.ToString())
 		}
 
 		prt.Infof("Offset %#08x", offset+idx)

--- a/cmd/tools/material-texture-name-dumper/main.go
+++ b/cmd/tools/material-texture-name-dumper/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 	prt.NoStatus()
 
-	files, err := a.MatchingFiles("", "", []string{"material"}, []stingray.Hash{}, "")
+	files, err := a.MatchingFiles("", "", []string{"material"}, []stingray.Hash{}, "", func(_ string, _ ...any) {})
 	if err != nil {
 		prt.Fatalf("%v", err)
 	}

--- a/cmd/tools/material-texture-name-dumper/main.go
+++ b/cmd/tools/material-texture-name-dumper/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/jwalton/go-supportscolor"
+	"github.com/xypwn/filediver/app"
+	"github.com/xypwn/filediver/app/appconfig"
+	"github.com/xypwn/filediver/config"
+	"github.com/xypwn/filediver/hashes"
+	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/stingray/unit/material"
+)
+
+var MissingGPUData error = errors.New("no gpu data")
+
+func main() {
+	prt := app.NewConsolePrinter(
+		supportscolor.Stderr().SupportsColor,
+		os.Stderr,
+		os.Stderr,
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		cancel()
+	}()
+
+	gameDir, err := app.DetectGameDir()
+	if err != nil {
+		prt.Fatalf("Unable to detect game install directory.")
+	}
+
+	knownHashes := hashes.ParseHashes(hashes.Hashes)
+	knownThinHashes := hashes.ParseHashes(hashes.ThinHashes)
+
+	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray.ThinHash{}, func(curr int, total int) {
+		prt.Statusf("Opening game directory %.0f%%", float64(curr)/float64(total)*100)
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			prt.NoStatus()
+			prt.Warnf("Physics dump canceled")
+			return
+		} else {
+			prt.Fatalf("%v", err)
+		}
+	}
+	prt.NoStatus()
+
+	files, err := a.MatchingFiles("", "", []string{"material"}, []stingray.Hash{}, "")
+	if err != nil {
+		prt.Fatalf("%v", err)
+	}
+
+	var cfg appconfig.Config
+	config.InitDefault(&cfg)
+	for fileId := range files {
+		mainData, err := a.DataDir.Read(fileId, stingray.DataMain)
+		if err != nil {
+			prt.Warnf("failed to load %v: %v", a.LookupHash(fileId.Name), err)
+			continue
+		}
+		material, err := material.LoadMain(bytes.NewReader(mainData))
+		if err != nil {
+			prt.Warnf("failed to parse %v: %v", a.LookupHash(fileId.Name), err)
+		}
+		detailData, ok := material.Textures[stingray.Sum("surface_data_array").Thin()]
+		if !ok {
+			continue
+		}
+		fmt.Println(a.LookupHash(detailData))
+	}
+}

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -1184,7 +1184,7 @@ func loadGeometryGroupMeshes(ctx *extractor.Context, doc *gltf.Document, unitInf
 
 	geoInfo, ok := geoGroup.MeshInfos[ctx.FileID().Name]
 	if !ok {
-		return fmt.Errorf("%v.geometry_group does not contain %v.unit", unitInfo.GeometryGroup.String(), ctx.LookupHash(ctx.File().ID().Name))
+		return fmt.Errorf("%v.geometry_group does not contain %v.unit", unitInfo.GeometryGroup.String(), ctx.LookupHash(ctx.FileID().Name))
 	}
 
 	gpuR, err := ctx.Open(geoID, stingray.DataGPU)

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -1183,12 +1183,8 @@ func loadGeometryGroupMeshes(ctx *extractor.Context, doc *gltf.Document, unitInf
 	}
 
 	geoInfo, ok := geoGroup.MeshInfos[ctx.FileID().Name]
-	unitName, contains := ctx.Hashes()[ctx.FileID().Name]
-	if !contains {
-		unitName = ctx.FileID().Name.String()
-	}
 	if !ok {
-		return fmt.Errorf("%v.geometry_group does not contain %v.unit", unitInfo.GeometryGroup.String(), unitName)
+		return fmt.Errorf("%v.geometry_group does not contain %v.unit", unitInfo.GeometryGroup.String(), ctx.LookupHash(ctx.File().ID().Name))
 	}
 
 	gpuR, err := ctx.Open(geoID, stingray.DataGPU)

--- a/patterns/dxbc.hexpat
+++ b/patterns/dxbc.hexpat
@@ -229,6 +229,19 @@ struct RDEF {
 };
 
 struct Element {
+    //u32 unk0;
+    string *name : u32 [[pointer_base("relative_to_parents_parents_parent")]];
+    u32 semantic_index;
+    u32 system_value_type;
+    u32 component_type;
+    u32 register;
+    u8 mask;
+    u8 rw_mask;
+    padding[2];
+    //u32 unk1;
+};
+
+struct OldElement {
     u32 unk0;
     string *name : u32 [[pointer_base("relative_to_parents_parents_parent")]];
     u32 semantic_index;
@@ -246,14 +259,19 @@ struct ISGN {
     List<Element, element_count> *elements : u32 [[pointer_base("relative_to_parent")]];
 };
 
-struct ISG1 {
+struct OSGN {
     u32 element_count;
     List<Element, element_count> *elements : u32 [[pointer_base("relative_to_parent")]];
 };
 
+struct ISG1 {
+    u32 element_count;
+    List<OldElement, element_count> *elements : u32 [[pointer_base("relative_to_parent")]];
+};
+
 struct OSG1 {
     u32 element_count;
-    List<Element, element_count> *elements : u32 [[pointer_base("relative_to_parent")]];
+    List<OldElement, element_count> *elements : u32 [[pointer_base("relative_to_parent")]];
 };
 
 enum D3D10_SB_TOKENIZED_PROGRAM_TYPE : u16 {
@@ -627,6 +645,9 @@ struct Part {
     } else if(header.name == "OSG1") {
         OSG1 data;
         padding[header.size - sizeof(data)];
+    } else if(header.name == "OSGN") {
+        OSGN data;
+        padding[header.size - sizeof(data)];
     } else if(header.name == "SHEX") {
         SHEX data;
         padding[header.size - sizeof(data)];
@@ -644,5 +665,4 @@ struct DXBC {
     Pointer<Part> parts[header.parts];
 };
 
-DXBC dxbc @0x9ed90;
-DXBC dxbc2 @0xbcfa0;
+DXBC dxbc @0x0;

--- a/patterns/dxbc.hexpat
+++ b/patterns/dxbc.hexpat
@@ -1,5 +1,9 @@
 #include <std/ptr.pat>
 
+fn relative_to_parents_parents_parents_parents_parent(u128 offset) {
+    return addressof(parent.parent.parent.parent.parent.parent);
+};
+
 fn relative_to_parents_parents_parents_parent(u128 offset) {
     return addressof(parent.parent.parent.parent.parent);
 };
@@ -16,6 +20,143 @@ fn relative_to_parent(u128 offset) {
     return addressof(parent.parent);
 };
 
+enum D3D_SHADER_VARIABLE_CLASS : u16 {
+    D3D_SVC_SCALAR = 0,
+    D3D_SVC_VECTOR,
+    D3D_SVC_MATRIX_ROWS,
+    D3D_SVC_MATRIX_COLUMNS,
+    D3D_SVC_OBJECT,
+    D3D_SVC_STRUCT,
+    D3D_SVC_INTERFACE_CLASS,
+    D3D_SVC_INTERFACE_POINTER,
+    D3D10_SVC_SCALAR,
+    D3D10_SVC_VECTOR,
+    D3D10_SVC_MATRIX_ROWS,
+    D3D10_SVC_MATRIX_COLUMNS,
+    D3D10_SVC_OBJECT,
+    D3D10_SVC_STRUCT,
+    D3D11_SVC_INTERFACE_CLASS,
+    D3D11_SVC_INTERFACE_POINTER,
+};
+
+enum D3D_SHADER_VARIABLE_TYPE : u16 {
+    D3D_SVT_VOID = 0,
+    D3D_SVT_BOOL = 1,
+    D3D_SVT_INT = 2,
+    D3D_SVT_FLOAT = 3,
+    D3D_SVT_STRING = 4,
+    D3D_SVT_TEXTURE = 5,
+    D3D_SVT_TEXTURE1D = 6,
+    D3D_SVT_TEXTURE2D = 7,
+    D3D_SVT_TEXTURE3D = 8,
+    D3D_SVT_TEXTURECUBE = 9,
+    D3D_SVT_SAMPLER = 10,
+    D3D_SVT_SAMPLER1D = 11,
+    D3D_SVT_SAMPLER2D = 12,
+    D3D_SVT_SAMPLER3D = 13,
+    D3D_SVT_SAMPLERCUBE = 14,
+    D3D_SVT_PIXELSHADER = 15,
+    D3D_SVT_VERTEXSHADER = 16,
+    D3D_SVT_PIXELFRAGMENT = 17,
+    D3D_SVT_VERTEXFRAGMENT = 18,
+    D3D_SVT_UINT = 19,
+    D3D_SVT_UINT8 = 20,
+    D3D_SVT_GEOMETRYSHADER = 21,
+    D3D_SVT_RASTERIZER = 22,
+    D3D_SVT_DEPTHSTENCIL = 23,
+    D3D_SVT_BLEND = 24,
+    D3D_SVT_BUFFER = 25,
+    D3D_SVT_CBUFFER = 26,
+    D3D_SVT_TBUFFER = 27,
+    D3D_SVT_TEXTURE1DARRAY = 28,
+    D3D_SVT_TEXTURE2DARRAY = 29,
+    D3D_SVT_RENDERTARGETVIEW = 30,
+    D3D_SVT_DEPTHSTENCILVIEW = 31,
+    D3D_SVT_TEXTURE2DMS = 32,
+    D3D_SVT_TEXTURE2DMSARRAY = 33,
+    D3D_SVT_TEXTURECUBEARRAY = 34,
+    D3D_SVT_HULLSHADER = 35,
+    D3D_SVT_DOMAINSHADER = 36,
+    D3D_SVT_INTERFACE_POINTER = 37,
+    D3D_SVT_COMPUTESHADER = 38,
+    D3D_SVT_DOUBLE = 39,
+    D3D_SVT_RWTEXTURE1D = 40,
+    D3D_SVT_RWTEXTURE1DARRAY = 41,
+    D3D_SVT_RWTEXTURE2D = 42,
+    D3D_SVT_RWTEXTURE2DARRAY = 43,
+    D3D_SVT_RWTEXTURE3D = 44,
+    D3D_SVT_RWBUFFER = 45,
+    D3D_SVT_BYTEADDRESS_BUFFER = 46,
+    D3D_SVT_RWBYTEADDRESS_BUFFER = 47,
+    D3D_SVT_STRUCTURED_BUFFER = 48,
+    D3D_SVT_RWSTRUCTURED_BUFFER = 49,
+    D3D_SVT_APPEND_STRUCTURED_BUFFER = 50,
+    D3D_SVT_CONSUME_STRUCTURED_BUFFER = 51,
+    D3D_SVT_MIN8FLOAT = 52,
+    D3D_SVT_MIN10FLOAT = 53,
+    D3D_SVT_MIN16FLOAT = 54,
+    D3D_SVT_MIN12INT = 55,
+    D3D_SVT_MIN16INT = 56,
+    D3D_SVT_MIN16UINT = 57,
+    D3D_SVT_INT16,
+    D3D_SVT_UINT16,
+    D3D_SVT_FLOAT16,
+    D3D_SVT_INT64,
+    D3D_SVT_UINT64,
+    D3D10_SVT_VOID,
+    D3D10_SVT_BOOL,
+    D3D10_SVT_INT,
+    D3D10_SVT_FLOAT,
+    D3D10_SVT_STRING,
+    D3D10_SVT_TEXTURE,
+    D3D10_SVT_TEXTURE1D,
+    D3D10_SVT_TEXTURE2D,
+    D3D10_SVT_TEXTURE3D,
+    D3D10_SVT_TEXTURECUBE,
+    D3D10_SVT_SAMPLER,
+    D3D10_SVT_SAMPLER1D,
+    D3D10_SVT_SAMPLER2D,
+    D3D10_SVT_SAMPLER3D,
+    D3D10_SVT_SAMPLERCUBE,
+    D3D10_SVT_PIXELSHADER,
+    D3D10_SVT_VERTEXSHADER,
+    D3D10_SVT_PIXELFRAGMENT,
+    D3D10_SVT_VERTEXFRAGMENT,
+    D3D10_SVT_UINT,
+    D3D10_SVT_UINT8,
+    D3D10_SVT_GEOMETRYSHADER,
+    D3D10_SVT_RASTERIZER,
+    D3D10_SVT_DEPTHSTENCIL,
+    D3D10_SVT_BLEND,
+    D3D10_SVT_BUFFER,
+    D3D10_SVT_CBUFFER,
+    D3D10_SVT_TBUFFER,
+    D3D10_SVT_TEXTURE1DARRAY,
+    D3D10_SVT_TEXTURE2DARRAY,
+    D3D10_SVT_RENDERTARGETVIEW,
+    D3D10_SVT_DEPTHSTENCILVIEW,
+    D3D10_SVT_TEXTURE2DMS,
+    D3D10_SVT_TEXTURE2DMSARRAY,
+    D3D10_SVT_TEXTURECUBEARRAY,
+    D3D11_SVT_HULLSHADER,
+    D3D11_SVT_DOMAINSHADER,
+    D3D11_SVT_INTERFACE_POINTER,
+    D3D11_SVT_COMPUTESHADER,
+    D3D11_SVT_DOUBLE,
+    D3D11_SVT_RWTEXTURE1D,
+    D3D11_SVT_RWTEXTURE1DARRAY,
+    D3D11_SVT_RWTEXTURE2D,
+    D3D11_SVT_RWTEXTURE2DARRAY,
+    D3D11_SVT_RWTEXTURE3D,
+    D3D11_SVT_RWBUFFER,
+    D3D11_SVT_BYTEADDRESS_BUFFER,
+    D3D11_SVT_RWBYTEADDRESS_BUFFER,
+    D3D11_SVT_STRUCTURED_BUFFER,
+    D3D11_SVT_RWSTRUCTURED_BUFFER,
+    D3D11_SVT_APPEND_STRUCTURED_BUFFER,
+    D3D11_SVT_CONSUME_STRUCTURED_BUFFER,
+};
+
 struct Header {
     char magic[4];
     u8 digest[16];
@@ -29,12 +170,24 @@ struct string {
     char data[];
 };
 
+struct Type {
+    D3D_SHADER_VARIABLE_CLASS var_class;
+    D3D_SHADER_VARIABLE_TYPE var_type;
+    u16 rows;
+    u16 cols;
+    u16 elements;
+    u16 members;
+    u16 member_offset;
+    u8 unk00[18];
+    string *name : u32 [[pointer_base("relative_to_parents_parents_parents_parents_parent")]];
+};
+
 struct Variable {
     string *name : u32 [[pointer_base("relative_to_parents_parents_parents_parent")]];
     u32 cb_offset;
     u32 size;
     u32 flags;
-    string *type : u32 [[pointer_base("relative_to_parents_parents_parents_parent")]];
+    Type *type : u32 [[pointer_base("relative_to_parents_parents_parents_parent")]];
     u32 default_value_offset;
     u32 unk[4];
 };
@@ -72,7 +225,381 @@ struct RDEF {
     u8 major;
     u16 program_type;
     u32 flags;
-    u32 creator_offset;
+    string *creator : u32 [[pointer_base("relative_to_parent")]];
+};
+
+struct Element {
+    u32 unk0;
+    string *name : u32 [[pointer_base("relative_to_parents_parents_parent")]];
+    u32 semantic_index;
+    u32 system_value_type;
+    u32 component_type;
+    u32 register;
+    u8 mask;
+    u8 rw_mask;
+    padding[2];
+    u32 unk1;
+};
+
+struct ISGN {
+    u32 element_count;
+    List<Element, element_count> *elements : u32 [[pointer_base("relative_to_parent")]];
+};
+
+struct ISG1 {
+    u32 element_count;
+    List<Element, element_count> *elements : u32 [[pointer_base("relative_to_parent")]];
+};
+
+struct OSG1 {
+    u32 element_count;
+    List<Element, element_count> *elements : u32 [[pointer_base("relative_to_parent")]];
+};
+
+enum D3D10_SB_TOKENIZED_PROGRAM_TYPE : u16 {
+    D3D10_SB_PIXEL_SHADER       = 0,
+    D3D10_SB_VERTEX_SHADER      = 1,
+    D3D10_SB_GEOMETRY_SHADER    = 2,
+    
+    // D3D11 Shaders
+    D3D11_SB_HULL_SHADER        = 3,
+    D3D11_SB_DOMAIN_SHADER      = 4,
+    D3D11_SB_COMPUTE_SHADER     = 5,
+
+    D3D11_SB_RESERVED0          = 0xFFF0
+};
+
+bitfield Version {
+    minor : 4;
+    major : 4;
+};
+
+enum D3D10_SB_OPCODE_TYPE : u16 {
+    D3D10_SB_OPCODE_ADD          ,
+    D3D10_SB_OPCODE_AND          ,
+    D3D10_SB_OPCODE_BREAK        ,
+    D3D10_SB_OPCODE_BREAKC       ,
+    D3D10_SB_OPCODE_CALL         ,
+    D3D10_SB_OPCODE_CALLC        ,
+    D3D10_SB_OPCODE_CASE         ,
+    D3D10_SB_OPCODE_CONTINUE     ,
+    D3D10_SB_OPCODE_CONTINUEC    ,
+    D3D10_SB_OPCODE_CUT          ,
+    D3D10_SB_OPCODE_DEFAULT      ,
+    D3D10_SB_OPCODE_DERIV_RTX    ,
+    D3D10_SB_OPCODE_DERIV_RTY    ,
+    D3D10_SB_OPCODE_DISCARD      ,
+    D3D10_SB_OPCODE_DIV          ,
+    D3D10_SB_OPCODE_DP2          ,
+    D3D10_SB_OPCODE_DP3          ,
+    D3D10_SB_OPCODE_DP4          ,
+    D3D10_SB_OPCODE_ELSE         ,
+    D3D10_SB_OPCODE_EMIT         ,
+    D3D10_SB_OPCODE_EMITTHENCUT  ,
+    D3D10_SB_OPCODE_ENDIF        ,
+    D3D10_SB_OPCODE_ENDLOOP      ,
+    D3D10_SB_OPCODE_ENDSWITCH    ,
+    D3D10_SB_OPCODE_EQ           ,
+    D3D10_SB_OPCODE_EXP          ,
+    D3D10_SB_OPCODE_FRC          ,
+    D3D10_SB_OPCODE_FTOI         ,
+    D3D10_SB_OPCODE_FTOU         ,
+    D3D10_SB_OPCODE_GE           ,
+    D3D10_SB_OPCODE_IADD         ,
+    D3D10_SB_OPCODE_IF           ,
+    D3D10_SB_OPCODE_IEQ          ,
+    D3D10_SB_OPCODE_IGE          ,
+    D3D10_SB_OPCODE_ILT          ,
+    D3D10_SB_OPCODE_IMAD         ,
+    D3D10_SB_OPCODE_IMAX         ,
+    D3D10_SB_OPCODE_IMIN         ,
+    D3D10_SB_OPCODE_IMUL         ,
+    D3D10_SB_OPCODE_INE          ,
+    D3D10_SB_OPCODE_INEG         ,
+    D3D10_SB_OPCODE_ISHL         ,
+    D3D10_SB_OPCODE_ISHR         ,
+    D3D10_SB_OPCODE_ITOF         ,
+    D3D10_SB_OPCODE_LABEL        ,
+    D3D10_SB_OPCODE_LD           ,
+    D3D10_SB_OPCODE_LD_MS        ,
+    D3D10_SB_OPCODE_LOG          ,
+    D3D10_SB_OPCODE_LOOP         ,
+    D3D10_SB_OPCODE_LT           ,
+    D3D10_SB_OPCODE_MAD          ,
+    D3D10_SB_OPCODE_MIN          ,
+    D3D10_SB_OPCODE_MAX          ,
+    D3D10_SB_OPCODE_CUSTOMDATA   ,
+    D3D10_SB_OPCODE_MOV          ,
+    D3D10_SB_OPCODE_MOVC         ,
+    D3D10_SB_OPCODE_MUL          ,
+    D3D10_SB_OPCODE_NE           ,
+    D3D10_SB_OPCODE_NOP          ,
+    D3D10_SB_OPCODE_NOT          ,
+    D3D10_SB_OPCODE_OR           ,
+    D3D10_SB_OPCODE_RESINFO      ,
+    D3D10_SB_OPCODE_RET          ,
+    D3D10_SB_OPCODE_RETC         ,
+    D3D10_SB_OPCODE_ROUND_NE     ,
+    D3D10_SB_OPCODE_ROUND_NI     ,
+    D3D10_SB_OPCODE_ROUND_PI     ,
+    D3D10_SB_OPCODE_ROUND_Z      ,
+    D3D10_SB_OPCODE_RSQ          ,
+    D3D10_SB_OPCODE_SAMPLE       ,
+    D3D10_SB_OPCODE_SAMPLE_C     ,
+    D3D10_SB_OPCODE_SAMPLE_C_LZ  ,
+    D3D10_SB_OPCODE_SAMPLE_L     ,
+    D3D10_SB_OPCODE_SAMPLE_D     ,
+    D3D10_SB_OPCODE_SAMPLE_B     ,
+    D3D10_SB_OPCODE_SQRT         ,
+    D3D10_SB_OPCODE_SWITCH       ,
+    D3D10_SB_OPCODE_SINCOS       ,
+    D3D10_SB_OPCODE_UDIV         ,
+    D3D10_SB_OPCODE_ULT          ,
+    D3D10_SB_OPCODE_UGE          ,
+    D3D10_SB_OPCODE_UMUL         ,
+    D3D10_SB_OPCODE_UMAD         ,
+    D3D10_SB_OPCODE_UMAX         ,
+    D3D10_SB_OPCODE_UMIN         ,
+    D3D10_SB_OPCODE_USHR         ,
+    D3D10_SB_OPCODE_UTOF         ,
+    D3D10_SB_OPCODE_XOR          ,
+    D3D10_SB_OPCODE_DCL_RESOURCE                     , // DCL* opcodes have
+    D3D10_SB_OPCODE_DCL_CONSTANT_BUFFER              , // custom operand formats.
+    D3D10_SB_OPCODE_DCL_SAMPLER                      ,
+    D3D10_SB_OPCODE_DCL_INDEX_RANGE                  ,
+    D3D10_SB_OPCODE_DCL_GS_OUTPUT_PRIMITIVE_TOPOLOGY ,
+    D3D10_SB_OPCODE_DCL_GS_INPUT_PRIMITIVE           ,
+    D3D10_SB_OPCODE_DCL_MAX_OUTPUT_VERTEX_COUNT      ,
+    D3D10_SB_OPCODE_DCL_INPUT                        ,
+    D3D10_SB_OPCODE_DCL_INPUT_SGV                    ,
+    D3D10_SB_OPCODE_DCL_INPUT_SIV                    ,
+    D3D10_SB_OPCODE_DCL_INPUT_PS                     ,
+    D3D10_SB_OPCODE_DCL_INPUT_PS_SGV                 ,
+    D3D10_SB_OPCODE_DCL_INPUT_PS_SIV                 ,
+    D3D10_SB_OPCODE_DCL_OUTPUT                       ,
+    D3D10_SB_OPCODE_DCL_OUTPUT_SGV                   ,
+    D3D10_SB_OPCODE_DCL_OUTPUT_SIV                   ,
+    D3D10_SB_OPCODE_DCL_TEMPS                        ,
+    D3D10_SB_OPCODE_DCL_INDEXABLE_TEMP               ,
+    D3D10_SB_OPCODE_DCL_GLOBAL_FLAGS                 ,
+
+// -----------------------------------------------
+
+    // This marks the end of D3D10.0 opcodes
+    D3D10_SB_OPCODE_RESERVED0,
+    
+// ---------- DX 10.1 op codes---------------------
+
+    D3D10_1_SB_OPCODE_LOD,
+    D3D10_1_SB_OPCODE_GATHER4,
+    D3D10_1_SB_OPCODE_SAMPLE_POS,
+    D3D10_1_SB_OPCODE_SAMPLE_INFO,
+
+// -----------------------------------------------
+
+    // This marks the end of D3D10.1 opcodes
+    D3D10_1_SB_OPCODE_RESERVED1,
+
+// ---------- DX 11 op codes---------------------
+    D3D11_SB_OPCODE_HS_DECLS                         , // token marks beginning of HS sub-shader
+    D3D11_SB_OPCODE_HS_CONTROL_POINT_PHASE           , // token marks beginning of HS sub-shader
+    D3D11_SB_OPCODE_HS_FORK_PHASE                    , // token marks beginning of HS sub-shader
+    D3D11_SB_OPCODE_HS_JOIN_PHASE                    , // token marks beginning of HS sub-shader
+
+    D3D11_SB_OPCODE_EMIT_STREAM                      ,
+    D3D11_SB_OPCODE_CUT_STREAM                       ,
+    D3D11_SB_OPCODE_EMITTHENCUT_STREAM               ,
+    D3D11_SB_OPCODE_INTERFACE_CALL                   ,
+
+    D3D11_SB_OPCODE_BUFINFO                          ,
+    D3D11_SB_OPCODE_DERIV_RTX_COARSE                 ,
+    D3D11_SB_OPCODE_DERIV_RTX_FINE                   ,
+    D3D11_SB_OPCODE_DERIV_RTY_COARSE                 ,
+    D3D11_SB_OPCODE_DERIV_RTY_FINE                   ,
+    D3D11_SB_OPCODE_GATHER4_C                        ,
+    D3D11_SB_OPCODE_GATHER4_PO                       ,
+    D3D11_SB_OPCODE_GATHER4_PO_C                     ,
+    D3D11_SB_OPCODE_RCP                              ,
+    D3D11_SB_OPCODE_F32TOF16                         ,
+    D3D11_SB_OPCODE_F16TOF32                         ,
+    D3D11_SB_OPCODE_UADDC                            ,
+    D3D11_SB_OPCODE_USUBB                            ,
+    D3D11_SB_OPCODE_COUNTBITS                        ,
+    D3D11_SB_OPCODE_FIRSTBIT_HI                      ,
+    D3D11_SB_OPCODE_FIRSTBIT_LO                      ,
+    D3D11_SB_OPCODE_FIRSTBIT_SHI                     ,
+    D3D11_SB_OPCODE_UBFE                             ,
+    D3D11_SB_OPCODE_IBFE                             ,
+    D3D11_SB_OPCODE_BFI                              ,
+    D3D11_SB_OPCODE_BFREV                            ,
+    D3D11_SB_OPCODE_SWAPC                            ,
+
+    D3D11_SB_OPCODE_DCL_STREAM                       ,
+    D3D11_SB_OPCODE_DCL_FUNCTION_BODY                ,
+    D3D11_SB_OPCODE_DCL_FUNCTION_TABLE               ,
+    D3D11_SB_OPCODE_DCL_INTERFACE                    ,
+    
+    D3D11_SB_OPCODE_DCL_INPUT_CONTROL_POINT_COUNT    ,
+    D3D11_SB_OPCODE_DCL_OUTPUT_CONTROL_POINT_COUNT   ,
+    D3D11_SB_OPCODE_DCL_TESS_DOMAIN                  ,
+    D3D11_SB_OPCODE_DCL_TESS_PARTITIONING            ,
+    D3D11_SB_OPCODE_DCL_TESS_OUTPUT_PRIMITIVE        ,
+    D3D11_SB_OPCODE_DCL_HS_MAX_TESSFACTOR            ,
+    D3D11_SB_OPCODE_DCL_HS_FORK_PHASE_INSTANCE_COUNT ,
+    D3D11_SB_OPCODE_DCL_HS_JOIN_PHASE_INSTANCE_COUNT ,
+
+    D3D11_SB_OPCODE_DCL_THREAD_GROUP                 ,
+    D3D11_SB_OPCODE_DCL_UNORDERED_ACCESS_VIEW_TYPED  ,
+    D3D11_SB_OPCODE_DCL_UNORDERED_ACCESS_VIEW_RAW    ,
+    D3D11_SB_OPCODE_DCL_UNORDERED_ACCESS_VIEW_STRUCTURED,
+    D3D11_SB_OPCODE_DCL_THREAD_GROUP_SHARED_MEMORY_RAW,
+    D3D11_SB_OPCODE_DCL_THREAD_GROUP_SHARED_MEMORY_STRUCTURED,
+    D3D11_SB_OPCODE_DCL_RESOURCE_RAW                 ,
+    D3D11_SB_OPCODE_DCL_RESOURCE_STRUCTURED          ,
+    D3D11_SB_OPCODE_LD_UAV_TYPED                     ,
+    D3D11_SB_OPCODE_STORE_UAV_TYPED                  ,
+    D3D11_SB_OPCODE_LD_RAW                           ,
+    D3D11_SB_OPCODE_STORE_RAW                        ,
+    D3D11_SB_OPCODE_LD_STRUCTURED                    ,
+    D3D11_SB_OPCODE_STORE_STRUCTURED                 ,
+    D3D11_SB_OPCODE_ATOMIC_AND                       ,
+    D3D11_SB_OPCODE_ATOMIC_OR                        ,
+    D3D11_SB_OPCODE_ATOMIC_XOR                       ,
+    D3D11_SB_OPCODE_ATOMIC_CMP_STORE                 ,
+    D3D11_SB_OPCODE_ATOMIC_IADD                      ,
+    D3D11_SB_OPCODE_ATOMIC_IMAX                      ,
+    D3D11_SB_OPCODE_ATOMIC_IMIN                      ,
+    D3D11_SB_OPCODE_ATOMIC_UMAX                      ,
+    D3D11_SB_OPCODE_ATOMIC_UMIN                      ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_ALLOC                 ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_CONSUME               ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_IADD                  ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_AND                   ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_OR                    ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_XOR                   ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_EXCH                  ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_CMP_EXCH              ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_IMAX                  ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_IMIN                  ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_UMAX                  ,
+    D3D11_SB_OPCODE_IMM_ATOMIC_UMIN                  ,   
+    D3D11_SB_OPCODE_SYNC                             ,
+    
+    D3D11_SB_OPCODE_DADD                             ,
+    D3D11_SB_OPCODE_DMAX                             ,
+    D3D11_SB_OPCODE_DMIN                             ,
+    D3D11_SB_OPCODE_DMUL                             ,
+    D3D11_SB_OPCODE_DEQ                              ,
+    D3D11_SB_OPCODE_DGE                              ,
+    D3D11_SB_OPCODE_DLT                              ,
+    D3D11_SB_OPCODE_DNE                              ,
+    D3D11_SB_OPCODE_DMOV                             ,
+    D3D11_SB_OPCODE_DMOVC                            ,
+    D3D11_SB_OPCODE_DTOF                             ,
+    D3D11_SB_OPCODE_FTOD                             ,
+
+    D3D11_SB_OPCODE_EVAL_SNAPPED                     ,
+    D3D11_SB_OPCODE_EVAL_SAMPLE_INDEX                ,
+    D3D11_SB_OPCODE_EVAL_CENTROID                    ,
+    
+    D3D11_SB_OPCODE_DCL_GS_INSTANCE_COUNT            ,
+
+    D3D11_SB_OPCODE_ABORT                            ,
+    D3D11_SB_OPCODE_DEBUG_BREAK                      ,
+
+// -----------------------------------------------
+
+    // This marks the end of D3D11.0 opcodes
+    D3D11_SB_OPCODE_RESERVED0,
+
+    D3D11_1_SB_OPCODE_DDIV,
+    D3D11_1_SB_OPCODE_DFMA,
+    D3D11_1_SB_OPCODE_DRCP,
+
+    D3D11_1_SB_OPCODE_MSAD,
+
+    D3D11_1_SB_OPCODE_DTOI,
+    D3D11_1_SB_OPCODE_DTOU,
+    D3D11_1_SB_OPCODE_ITOD,
+    D3D11_1_SB_OPCODE_UTOD,
+
+// -----------------------------------------------
+
+    // This marks the end of D3D11.1 opcodes
+    D3D11_1_SB_OPCODE_RESERVED0,
+
+    D3DWDDM1_3_SB_OPCODE_GATHER4_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_GATHER4_C_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_GATHER4_PO_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_GATHER4_PO_C_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_LD_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_LD_MS_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_LD_UAV_TYPED_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_LD_RAW_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_LD_STRUCTURED_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_SAMPLE_L_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_SAMPLE_C_LZ_FEEDBACK,
+
+    D3DWDDM1_3_SB_OPCODE_SAMPLE_CLAMP_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_SAMPLE_B_CLAMP_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_SAMPLE_D_CLAMP_FEEDBACK,
+    D3DWDDM1_3_SB_OPCODE_SAMPLE_C_CLAMP_FEEDBACK,
+
+    D3DWDDM1_3_SB_OPCODE_CHECK_ACCESS_FULLY_MAPPED,
+
+// -----------------------------------------------
+
+    // This marks the end of WDDM 1.3 opcodes
+    D3DWDDM1_3_SB_OPCODE_RESERVED0,
+
+    D3D10_SB_NUM_OPCODES                                     // Should be the last entry
+};
+
+enum D3D10_SB_RESINFO_INSTRUCTION_RETURN_TYPE : u8 {
+    FLOAT      = 0,
+    RCPFLOAT   = 1,
+    UINT       = 2,
+};
+
+enum D3D10_SB_CUSTOMDATA_CLASS : u32 {
+    D3D10_SB_CUSTOMDATA_COMMENT = 0,
+    D3D10_SB_CUSTOMDATA_DEBUGINFO,
+    D3D10_SB_CUSTOMDATA_OPAQUE,
+    D3D10_SB_CUSTOMDATA_DCL_IMMEDIATE_CONSTANT_BUFFER,
+    D3D11_SB_CUSTOMDATA_SHADER_MESSAGE,
+    D3D11_SB_CUSTOMDATA_SHADER_CLIP_PLANE_CONSTANT_MAPPINGS_FOR_DX9,
+};
+
+struct Opcode {
+    u32 opcode [[hidden]];
+    D3D10_SB_OPCODE_TYPE type = opcode & 0x07ff [[export]];
+    if (type == D3D10_SB_OPCODE_TYPE::D3D10_SB_OPCODE_CUSTOMDATA) {
+        D3D10_SB_CUSTOMDATA_CLASS class = (opcode & 0xfffff800) >> 11 [[export]];
+        u32 size;
+        u32 data[size-2];
+    } else {
+        u8 length = (opcode & 0x7f000000) >> 24 [[export]];
+        bool saturate = (opcode & 0x00002000) != 0 [[export]];
+        u8 test_boolean = (opcode & 0x00040000) >> 18 [[export]];
+        u8 precise_mask = (opcode & 0x00780000) >> 19 [[export]];
+        D3D10_SB_RESINFO_INSTRUCTION_RETURN_TYPE return_type = (opcode & 0x00001800) >> 11 [[export]];
+        bool sync_threads = (opcode & 0x00000800) != 0 [[export]];
+        bool sync_thread_group_shm = (opcode & 0x00001000) != 0 [[export]];
+        bool sync_unordered_access_memory_group = (opcode & 0x00002000) != 0 [[export]];
+        bool sync_unordered_access_memory_global = (opcode & 0x00004000) != 0 [[export]];
+        bool extended = (opcode & 0x80000000) != 0 [[export]];
+        if (length > 1)
+            u32 data[length-1];
+    }
+};
+
+struct SHEX {
+    u64 begin = $;
+    Version version;
+    u8 reserved;
+    D3D10_SB_TOKENIZED_PROGRAM_TYPE program_type;
+    u32 num_dwords;
+    Opcode opcodes[while($ < begin+(num_dwords-2)*4)];
 };
 
 struct PartHeader {
@@ -84,6 +611,18 @@ struct Part {
     PartHeader header;
     if(header.name == "RDEF") {
         RDEF data;
+        padding[header.size - sizeof(data)];
+    } else if(header.name == "ISGN") {
+        ISGN data;
+        padding[header.size - sizeof(data)];
+    } else if(header.name == "ISG1") {
+        ISG1 data;
+        padding[header.size - sizeof(data)];
+    } else if(header.name == "OSG1") {
+        OSG1 data;
+        padding[header.size - sizeof(data)];
+    } else if(header.name == "SHEX") {
+        SHEX data;
         padding[header.size - sizeof(data)];
     } else {
         u8 data[header.size];
@@ -99,4 +638,4 @@ struct DXBC {
     Pointer<Part> parts[header.parts];
 };
 
-DXBC dxbc @0xffbefc80;
+DXBC dxbc @0x9ed90;

--- a/patterns/dxbc.hexpat
+++ b/patterns/dxbc.hexpat
@@ -593,13 +593,19 @@ struct Opcode {
     }
 };
 
+#define PARSE_OPCODES false
+
 struct SHEX {
     u64 begin = $;
     Version version;
     u8 reserved;
     D3D10_SB_TOKENIZED_PROGRAM_TYPE program_type;
     u32 num_dwords;
-    Opcode opcodes[while($ < begin+(num_dwords-2)*4)];
+    if(PARSE_OPCODES) {
+        Opcode opcodes[while($ < begin+num_dwords*4)];
+    } else {
+        u32 opcode_data[while($ < begin+num_dwords*4)];
+    }
 };
 
 struct PartHeader {
@@ -639,3 +645,4 @@ struct DXBC {
 };
 
 DXBC dxbc @0x9ed90;
+DXBC dxbc2 @0xbcfa0;

--- a/patterns/geometry_group.hexpat
+++ b/patterns/geometry_group.hexpat
@@ -89,8 +89,11 @@ struct MeshInfo {
 enum MeshLayoutItemType : u32 {
     Position,
     Normal,
-    UVCoords = 4,
-    BoneIdx = 6,
+    Tangent,
+    Binormal,
+    UVCoords,
+    Color,
+    BoneIdx,
     BoneWeight
 };
 

--- a/patterns/material.gpu.hexpat
+++ b/patterns/material.gpu.hexpat
@@ -323,7 +323,7 @@ namespace d3d {
         D3D10_SB_PIXEL_SHADER       = 0,
         D3D10_SB_VERTEX_SHADER      = 1,
         D3D10_SB_GEOMETRY_SHADER    = 2,
-        
+
         // D3D11 Shaders
         D3D11_SB_HULL_SHADER        = 3,
         D3D11_SB_DOMAIN_SHADER      = 4,
@@ -450,7 +450,7 @@ namespace d3d {
 
         // This marks the end of D3D10.0 opcodes
         D3D10_SB_OPCODE_RESERVED0,
-        
+
     // ---------- DX 10.1 op codes---------------------
 
         D3D10_1_SB_OPCODE_LOD,
@@ -501,7 +501,7 @@ namespace d3d {
         D3D11_SB_OPCODE_DCL_FUNCTION_BODY                ,
         D3D11_SB_OPCODE_DCL_FUNCTION_TABLE               ,
         D3D11_SB_OPCODE_DCL_INTERFACE                    ,
-        
+
         D3D11_SB_OPCODE_DCL_INPUT_CONTROL_POINT_COUNT    ,
         D3D11_SB_OPCODE_DCL_OUTPUT_CONTROL_POINT_COUNT   ,
         D3D11_SB_OPCODE_DCL_TESS_DOMAIN                  ,
@@ -545,9 +545,9 @@ namespace d3d {
         D3D11_SB_OPCODE_IMM_ATOMIC_IMAX                  ,
         D3D11_SB_OPCODE_IMM_ATOMIC_IMIN                  ,
         D3D11_SB_OPCODE_IMM_ATOMIC_UMAX                  ,
-        D3D11_SB_OPCODE_IMM_ATOMIC_UMIN                  ,   
+        D3D11_SB_OPCODE_IMM_ATOMIC_UMIN                  ,
         D3D11_SB_OPCODE_SYNC                             ,
-        
+
         D3D11_SB_OPCODE_DADD                             ,
         D3D11_SB_OPCODE_DMAX                             ,
         D3D11_SB_OPCODE_DMIN                             ,
@@ -564,7 +564,7 @@ namespace d3d {
         D3D11_SB_OPCODE_EVAL_SNAPPED                     ,
         D3D11_SB_OPCODE_EVAL_SAMPLE_INDEX                ,
         D3D11_SB_OPCODE_EVAL_CENTROID                    ,
-        
+
         D3D11_SB_OPCODE_DCL_GS_INSTANCE_COUNT            ,
 
         D3D11_SB_OPCODE_ABORT                            ,
@@ -872,7 +872,7 @@ struct ShaderProgramList {
     padding[12];
     std::mem::AlignTo<8> align;
     u128 programCounts[count];
-    
+
     ShaderProgramBlock programs[count];
 };
 

--- a/patterns/unit.hexpat
+++ b/patterns/unit.hexpat
@@ -166,8 +166,11 @@ struct MeshGroupList {
 enum MeshLayoutItemType : u32 {
     Position,
     Normal,
-    UVCoords = 4,
-    BoneIdx = 6,
+    Tangent,
+    Binormal,
+    UVCoords,
+    Color,
+    BoneIdx,
     BoneWeight
 };
 
@@ -354,7 +357,7 @@ u32 MeshDataOffset = 4;
 
 fn calculateMeshDataOffset(u32 meshOffset) {
     while(
-        (meshOffset + MeshDataOffset) < std::mem::size() 
+        (meshOffset + MeshDataOffset) < std::mem::size()
         && std::mem::read_unsigned(meshOffset + MeshDataOffset, 1) == 0x00
     ) {
         MeshDataOffset = MeshDataOffset + 1;

--- a/scripts/resources/Helldivers2 shader script v1.0.6 cape.py
+++ b/scripts/resources/Helldivers2 shader script v1.0.6 cape.py
@@ -6299,12 +6299,12 @@ def create_HD2_Shader(context, operator, group_name, material: Optional[Material
     principled_bsdf_001.distribution = 'MULTI_GGX'
     principled_bsdf_001.subsurface_method = 'RANDOM_WALK'
     #Decal Mix Color -> principled_bsdf_001.Base Color
-    HD2_Shader.links.new(decal_mix_node.outputs[2], principled_bsdf_001.inputs[0])
+    HD2_Shader.links.new(decal_mix_node.outputs[2], principled_bsdf_001.inputs['Base Color'])
     #IOR
-    principled_bsdf_001.inputs[3].default_value = 1.4500000476837158
+    principled_bsdf_001.inputs['IOR'].default_value = 1.4500000476837158
     #Cape Control Mask Alpha -> principled_bsdf_001 Alpha
     HD2_Shader.links.new(group_input_1.outputs[3], alpha_cutoff_node.inputs[0])
-    HD2_Shader.links.new(alpha_cutoff_node.outputs[0], principled_bsdf_001.inputs[4])
+    HD2_Shader.links.new(alpha_cutoff_node.outputs[0], principled_bsdf_001.inputs['Alpha'])
     #Weight
     if 'Weight' in principled_bsdf_001.inputs:
         principled_bsdf_001.inputs['Weight'].default_value = 0.0

--- a/stingray/unit/material/d3d/opcodes/add.go
+++ b/stingray/unit/material/d3d/opcodes/add.go
@@ -1,0 +1,1 @@
+package d3dops

--- a/stingray/unit/material/d3d/opcodes/add.go
+++ b/stingray/unit/material/d3d/opcodes/add.go
@@ -1,1 +1,0 @@
-package d3dops

--- a/stingray/unit/material/d3d/opcodes/instructionToken.go
+++ b/stingray/unit/material/d3d/opcodes/instructionToken.go
@@ -810,7 +810,20 @@ func (tok *InstructionToken) quintenaryOpGLSL(opType ShaderOpcodeType, cbs []Con
 		expr,
 	)
 
-	return toReturn + fmt.Sprintf(" // %v\n", tok.operands[0].OperandToken0.Type().ToString())
+	if tok.Saturate() {
+		expr = fmt.Sprintf("clamp(%v, 0.0, 1.0)", expr)
+	}
+	if opType.ReturnNumberType() != internalNumberTypeFloat {
+		expr = fmt.Sprintf("%v(%v)", opType.ReturnNumberType().BitcastToFloat(), expr)
+	}
+
+	toReturn += fmt.Sprintf(
+		"%v = %v;",
+		tok.operands[0].ToGLSL(cbs, isg, osg, res, masks[0], true),
+		expr,
+	)
+
+	return toReturn + "\n"
 }
 
 func ParseInstruction(opcode uint32, data []uint8) (Opcode, error) {

--- a/stingray/unit/material/d3d/opcodes/instructionToken.go
+++ b/stingray/unit/material/d3d/opcodes/instructionToken.go
@@ -810,7 +810,7 @@ func (tok *InstructionToken) quintenaryOpGLSL(opType ShaderOpcodeType, cbs []Con
 		expr,
 	)
 
-	return toReturn + "\n"
+	return toReturn + fmt.Sprintf(" // %v\n", tok.operands[0].OperandToken0.Type().ToString())
 }
 
 func ParseInstruction(opcode uint32, data []uint8) (Opcode, error) {

--- a/stingray/unit/material/d3d/opcodes/instructionToken.go
+++ b/stingray/unit/material/d3d/opcodes/instructionToken.go
@@ -819,7 +819,7 @@ func (tok *InstructionToken) quintenaryOpGLSL(opType ShaderOpcodeType, cbs []Con
 
 	toReturn += fmt.Sprintf(
 		"%v = %v;",
-		tok.operands[0].ToGLSL(cbs, isg, osg, res, masks[0], true),
+		tok.operands[0].ToGLSL(cbs, isg, osg, res, masks[0], true, false),
 		expr,
 	)
 

--- a/stingray/unit/unit.go
+++ b/stingray/unit/unit.go
@@ -179,6 +179,7 @@ const (
 	ItemPosition          MeshLayoutItemType = 0
 	ItemNormal            MeshLayoutItemType = 1
 	ItemTangent           MeshLayoutItemType = 2
+	ItemBinormal          MeshLayoutItemType = 3
 	ItemUVCoords          MeshLayoutItemType = 4
 	ItemColor             MeshLayoutItemType = 5
 	ItemBoneIdx           MeshLayoutItemType = 6


### PR DESCRIPTION
This PR is targeting improving the display of units in the GUI by loading data directly and translating the game shaders to GLSL for us to use (and export!). There's still a lot of work to do on this PR (I haven't even gotten the shaders displaying anything yet, but the armor and building shaders do compile and link), but I wanted to get it put up so the project was more visible.

Goals for this PR:
- [x] Display models with geometry_group data
- [x] Load models directly instead of converting data formats
- [ ] Render models with game shaders applied
- [ ] Use the shaders to bake textures on export
- [ ] More material GPU format enhancements