### PR TITLE
fix(wwise): warn instead of error on missing HIRC stream references

### DIFF
--- a/cmd/filediver-gui/widgets/previews/auto_preview.go
+++ b/cmd/filediver-gui/widgets/previews/auto_preview.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"maps"
 	"path"
 	"slices"
@@ -158,7 +159,7 @@ func (pv *AutoPreviewState) LoadFile(ctx context.Context, fileID stingray.FileID
 		}
 		pv.state.audio.Title = bnkFile
 		dir := path.Dir(bnkFile)
-		streams, err := stingray_wwise.BnkGetAllReferencedStreamData(
+		streams, warnings, err := stingray_wwise.BnkGetAllReferencedStreamData(
 			bytes.NewReader(data[stingray.DataMain]),
 			func(id uint32) (data []byte, exists bool, err error) {
 				fileID := stingray.FileID{
@@ -171,6 +172,9 @@ func (pv *AutoPreviewState) LoadFile(ctx context.Context, fileID stingray.FileID
 		if err != nil {
 			pv.err = fmt.Errorf("loading wwise bank: %w", err)
 			return
+		}
+		for _, w := range warnings {
+			log.Println("wwise bank:", w)
 		}
 		for _, id := range slices.Sorted(maps.Keys(streams)) {
 			stream := streams[id]

--- a/extractor/wwise/extractor.go
+++ b/extractor/wwise/extractor.go
@@ -255,7 +255,7 @@ func ConvertBnk(ctx *extractor.Context) error {
 		return path.Join(dir, fmt.Sprint(resourceID))
 	}
 
-	streams, err := stingray_wwise.BnkGetAllReferencedStreamData(in, func(id uint32) (data []byte, exists bool, err error) {
+	streams, warnings, err := stingray_wwise.BnkGetAllReferencedStreamData(in, func(id uint32) (data []byte, exists bool, err error) {
 		streamFileName := stingray.Sum(streamFilePath(id))
 		streamFile, err := ctx.Open(stingray.NewFileID(streamFileName, stingray.Sum("wwise_stream")), stingray.DataStream)
 		if err == stingray.ErrFileNotExist || err == stingray.ErrFileDataTypeNotExist {
@@ -269,6 +269,9 @@ func ConvertBnk(ctx *extractor.Context) error {
 	})
 	if err != nil {
 		return err
+	}
+	for _, w := range warnings {
+		ctx.Warnf("%s", w)
 	}
 
 	for id, data := range streams {

--- a/stingray/wwise/wwise.go
+++ b/stingray/wwise/wwise.go
@@ -58,12 +58,13 @@ func OpenBnk(in io.ReadSeeker) (*wwise.Bnk, error) {
 func BnkGetAllReferencedStreamData(
 	in io.ReadSeeker,
 	tryGetStreamByID func(id uint32) (data []byte, exists bool, err error),
-) (map[uint32][]byte, error) {
+) (map[uint32][]byte, []string, error) {
 	streams := make(map[uint32][]byte)
+	var warnings []string
 
 	bnk, err := OpenBnk(in)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for i := 0; i < bnk.NumFiles(); i++ {
@@ -71,16 +72,16 @@ func BnkGetAllReferencedStreamData(
 		// Stream should either exist as a wwise stream, or be embedded in the wwise bank file
 		data, ok, err := tryGetStreamByID(id)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !ok {
 			rd, err := bnk.OpenFile(i)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			b, err := io.ReadAll(rd)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			data = b
 		}
@@ -101,14 +102,15 @@ func BnkGetAllReferencedStreamData(
 			fileID := obj.Header.ObjectID
 			data, ok, err := tryGetStreamByID(resourceID)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if !ok {
-				return nil, fmt.Errorf("referenced wwise stream resource with file ID %v does not exist", resourceID)
+				warnings = append(warnings, fmt.Sprintf("referenced wwise stream resource with file ID %v does not exist", resourceID))
+				continue
 			}
 			streams[fileID] = data
 		}
 	}
 
-	return streams, nil
+	return streams, warnings, nil
 }


### PR DESCRIPTION
Fixes #191 

## Problem
`BnkGetAllReferencedStreamData` returned a hard error when a referenced
`wwise_stream` didn't exist, causing the entire bank to be skipped.

## Solution
Change the missing-stream case from a fatal error to a collected warning.
The function's return signature changes from `(map[uint32][]byte, error)` to
`(map[uint32][]byte, []string, error)`. Both the extractor and GUI preview
callers log warnings and continue, extracting/showing all available streams.

## Testing
- Built and ran the GUI
- Selected a bank that previously showed the "does not exist" error
- Confirmed available audio streams now load in the preview panel and extract successfully
- Warnings are logged for the missing streams

<img width="790" height="496" alt="image" src="https://github.com/user-attachments/assets/e30a4a6b-a898-4e2a-be0c-7f39c16903f3" />
<img width="848" height="788" alt="image" src="https://github.com/user-attachments/assets/68227f70-0d9d-4be2-9b7c-3e31e3a60cc1" />
