### PR TITLE
Allow previews of terrain and geometry_group units

### DIFF
--- a/cmd/filediver-gui/widgets/previews/unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/unit_preview.go
@@ -23,6 +23,7 @@ import (
 	"github.com/xypwn/filediver/dds"
 	"github.com/xypwn/filediver/stingray"
 	"github.com/xypwn/filediver/stingray/unit"
+	geometrygroup "github.com/xypwn/filediver/stingray/unit/geometry_group"
 	"github.com/xypwn/filediver/stingray/unit/material"
 	"github.com/xypwn/filediver/stingray/unit/texture"
 )
@@ -237,12 +238,12 @@ func (pv *UnitPreviewState) Delete() {
 	pv.dbgObj.deleteObjects()
 }
 
-func (pv *UnitPreviewState) loadMesh(info *unit.Info, gpuData []byte) (unit.Mesh, error) {
+func (pv *UnitPreviewState) loadMesh(meshInfos []unit.MeshInfo, meshLayouts []unit.MeshLayout, gpuData []byte) (unit.Mesh, error) {
 	var meshToLoad uint32
 	{
 		highestDetailIdx := -1
 		highestDetailCount := -1
-		for i, info := range info.MeshInfos {
+		for i, info := range meshInfos {
 			for _, group := range info.Groups {
 				if int(group.NumIndices) > highestDetailCount && info.Header.MeshType != unit.MeshTypeUnknown00 {
 					highestDetailIdx = i
@@ -258,7 +259,7 @@ func (pv *UnitPreviewState) loadMesh(info *unit.Info, gpuData []byte) (unit.Mesh
 
 	var mesh unit.Mesh
 	{
-		meshes, err := unit.LoadMeshes(bytes.NewReader(gpuData), info, []uint32{meshToLoad})
+		meshes, err := unit.LoadMeshes(bytes.NewReader(gpuData), meshInfos, meshLayouts, []uint32{meshToLoad})
 		if err != nil {
 			return unit.Mesh{}, err
 		}
@@ -273,13 +274,13 @@ func (pv *UnitPreviewState) LoadUnit(fileID stingray.Hash, mainData, gpuData []b
 		return err
 	}
 
-	if len(info.MeshInfos) == 0 && len(info.TerrainInfos) == 0 {
+	if len(info.MeshInfos) == 0 && len(info.TerrainInfos) == 0 && info.GeometryGroup.Value == 0x0 {
 		return fmt.Errorf("unit contains no meshes")
 	}
 
 	var mesh unit.Mesh
 	if len(info.MeshInfos) > 0 {
-		mesh, err = pv.loadMesh(info, gpuData)
+		mesh, err = pv.loadMesh(info.MeshInfos, info.MeshLayouts, gpuData)
 		if err != nil {
 			return err
 		}
@@ -294,6 +295,44 @@ func (pv *UnitPreviewState) LoadUnit(fileID stingray.Hash, mainData, gpuData []b
 			mesh.Normals[i] = terrainConversionMatrix.Mul4x1(mgl32.Vec3(mesh.Normals[i]).Vec4(1)).Vec3()
 			mesh.Tangents[i] = terrainConversionMatrix.Mul4x1(mgl32.Vec3(mesh.Tangents[i]).Vec4(1)).Vec3()
 			mesh.Bitangents[i] = terrainConversionMatrix.Mul4x1(mgl32.Vec3(mesh.Bitangents[i]).Vec4(1)).Vec3()
+		}
+	}
+	if info.GeometryGroup.Value != 0x0 {
+		geoID := stingray.NewFileID(info.GeometryGroup, stingray.Sum("geometry_group"))
+		geoMain, exists, err := getResource(geoID, stingray.DataMain)
+		if !exists {
+			return fmt.Errorf("%v.geometry_group does not exist", info.GeometryGroup.String())
+		} else if err != nil {
+			return fmt.Errorf("failed to load %v.geometry_group: %v", info.GeometryGroup.String(), err)
+		}
+		geoGroup, err := geometrygroup.LoadGeometryGroup(bytes.NewReader(geoMain))
+		if err != nil {
+			return fmt.Errorf("failed to parse %v.geometry_group: %v", info.GeometryGroup.String(), err)
+		}
+		geoInfo, ok := geoGroup.MeshInfos[fileID]
+		if !ok {
+			return fmt.Errorf("%v.geometry_group does not contain %v.unit", info.GeometryGroup.String(), fileID)
+		}
+		meshInfos := make([]unit.MeshInfo, 0)
+		for _, header := range geoInfo.MeshHeaders {
+			meshInfos = append(meshInfos, unit.MeshInfo{
+				Groups: header.Groups,
+				Header: unit.MeshHeader{
+					MeshType:  unit.MeshTypeUnknown01,
+					LayoutIdx: int32(header.MeshLayoutIndex),
+				},
+				Materials: header.Materials,
+			})
+		}
+		geoGPU, exists, err := getResource(geoID, stingray.DataGPU)
+		if !exists {
+			return fmt.Errorf("%v.geometry_group missing gpu data", info.GeometryGroup.String())
+		} else if err != nil {
+			return fmt.Errorf("failed to load %v.geometry_group gpu data: %v", info.GeometryGroup.String(), err)
+		}
+		mesh, err = pv.loadMesh(meshInfos, geoGroup.MeshLayouts, geoGPU)
+		if err != nil {
+			return err
 		}
 	}
 	{
@@ -447,7 +486,7 @@ func (pv *UnitPreviewState) LoadUnit(fileID stingray.Hash, mainData, gpuData []b
 		pv.numUdims = max(pv.numUdims, udim+1)
 	}
 	if pv.numUdims >= 64 {
-		return fmt.Errorf("expected at most 64 udims, but got %v", pv.numUdims)
+		pv.numUdims = 1
 	}
 
 	// Upload object data

--- a/cmd/filediver-gui/widgets/previews/unit_preview.go
+++ b/cmd/filediver-gui/widgets/previews/unit_preview.go
@@ -237,16 +237,7 @@ func (pv *UnitPreviewState) Delete() {
 	pv.dbgObj.deleteObjects()
 }
 
-func (pv *UnitPreviewState) LoadUnit(fileID stingray.Hash, mainData, gpuData []byte, getResource GetResourceFunc, thinhashes map[stingray.ThinHash]string) error {
-	info, err := unit.LoadInfo(bytes.NewReader(mainData))
-	if err != nil {
-		return err
-	}
-
-	if len(info.MeshInfos) == 0 {
-		return fmt.Errorf("unit contains no meshes")
-	}
-
+func (pv *UnitPreviewState) loadMesh(info *unit.Info, gpuData []byte) (unit.Mesh, error) {
 	var meshToLoad uint32
 	{
 		highestDetailIdx := -1
@@ -260,7 +251,7 @@ func (pv *UnitPreviewState) LoadUnit(fileID stingray.Hash, mainData, gpuData []b
 			}
 		}
 		if highestDetailIdx == -1 {
-			return fmt.Errorf("unable to find mesh to load")
+			return unit.Mesh{}, fmt.Errorf("unable to find mesh to load")
 		}
 		meshToLoad = uint32(highestDetailIdx)
 	}
@@ -269,9 +260,41 @@ func (pv *UnitPreviewState) LoadUnit(fileID stingray.Hash, mainData, gpuData []b
 	{
 		meshes, err := unit.LoadMeshes(bytes.NewReader(gpuData), info, []uint32{meshToLoad})
 		if err != nil {
-			return err
+			return unit.Mesh{}, err
 		}
 		mesh = meshes[meshToLoad]
+	}
+	return mesh, nil
+}
+
+func (pv *UnitPreviewState) LoadUnit(fileID stingray.Hash, mainData, gpuData []byte, getResource GetResourceFunc, thinhashes map[stingray.ThinHash]string) error {
+	info, err := unit.LoadInfo(bytes.NewReader(mainData))
+	if err != nil {
+		return err
+	}
+
+	if len(info.MeshInfos) == 0 && len(info.TerrainInfos) == 0 {
+		return fmt.Errorf("unit contains no meshes")
+	}
+
+	var mesh unit.Mesh
+	if len(info.MeshInfos) > 0 {
+		mesh, err = pv.loadMesh(info, gpuData)
+		if err != nil {
+			return err
+		}
+	} else if len(info.TerrainInfos) > 0 {
+		mesh, err = unit.LoadTerrain(info.TerrainInfos[0])
+		if err != nil {
+			return err
+		}
+		terrainConversionMatrix := mgl32.Rotate3DX(math.Pi).Mat4().Mul4(stingray.ToGLTFMatrix)
+		for i := range mesh.Positions {
+			mesh.Positions[i] = terrainConversionMatrix.Mul4x1(mgl32.Vec3(mesh.Positions[i]).Vec4(1)).Vec3()
+			mesh.Normals[i] = terrainConversionMatrix.Mul4x1(mgl32.Vec3(mesh.Normals[i]).Vec4(1)).Vec3()
+			mesh.Tangents[i] = terrainConversionMatrix.Mul4x1(mgl32.Vec3(mesh.Tangents[i]).Vec4(1)).Vec3()
+			mesh.Bitangents[i] = terrainConversionMatrix.Mul4x1(mgl32.Vec3(mesh.Bitangents[i]).Vec4(1)).Vec3()
+		}
 	}
 	{
 		pv.aabb = [2]mgl32.Vec3{mesh.Info.Header.AABB.Min, mesh.Info.Header.AABB.Max}

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -575,46 +575,17 @@ func AddLights(ctx *extractor.Context, doc *gltf.Document, unitInfo *unit.Info, 
 func AddTerrain(ctx *extractor.Context, doc *gltf.Document, unitInfo *unit.Info, meshNodes *[]uint32) []uint32 {
 	terrainNodes := make([]uint32, 0)
 	for _, terrainInfo := range unitInfo.TerrainInfos {
-		if uint32(math.Sqrt(float64(len(terrainInfo.HeightmapData)/2))) != terrainInfo.Textures[0].Resolution {
-			ctx.Warnf("terrain %v.unit heightmap data length sqrt != texture[0] resolution: %v != %v", uint32(math.Sqrt(float64(len(terrainInfo.HeightmapData)/2))), terrainInfo.Textures[0].Resolution)
+		mesh, err := unit.LoadTerrain(terrainInfo)
+		if err != nil {
+			ctx.Warnf("Error loading terrain: %v", err)
 			return terrainNodes
-		}
-		terrainValues := make([]uint16, len(terrainInfo.HeightmapData)/2)
-		if _, err := binary.Decode(terrainInfo.HeightmapData, binary.LittleEndian, terrainValues); err != nil {
-			ctx.Warnf("decoding terrain values: %v", err)
-			return terrainNodes
-		}
-
-		decompressHeight := func(value uint16, min, max float32) float32 {
-			percent := float32(value) / 65535.0
-			return (percent - 0.5) * (max - min)
-		}
-		vertices := make([][3]float32, 0)
-		indices := make([]uint32, 0)
-		for y := range terrainInfo.Textures[0].Resolution {
-			for x := range terrainInfo.Textures[0].Resolution {
-				vertices = append(vertices, [3]float32{
-					(terrainInfo.Max[0]-terrainInfo.Min[0])*(float32(x)/float32(terrainInfo.Textures[0].Resolution)) + terrainInfo.Min[0],
-					decompressHeight(terrainValues[y*terrainInfo.Textures[0].Resolution+x], terrainInfo.Min[2], terrainInfo.Max[2]),
-					-((terrainInfo.Max[1]-terrainInfo.Min[1])*(float32(y)/float32(terrainInfo.Textures[0].Resolution)) + terrainInfo.Min[1]),
-				})
-			}
-		}
-
-		for quadY := range terrainInfo.Textures[0].Resolution - 1 {
-			for quadX := range terrainInfo.Textures[0].Resolution - 1 {
-				// face 0
-				indices = append(indices, (quadY)*terrainInfo.Textures[0].Resolution+(quadX), (quadY+1)*terrainInfo.Textures[0].Resolution+(quadX+1), (quadY)*terrainInfo.Textures[0].Resolution+(quadX+1))
-				// face 1
-				indices = append(indices, (quadY)*terrainInfo.Textures[0].Resolution+(quadX), (quadY+1)*terrainInfo.Textures[0].Resolution+(quadX), (quadY+1)*terrainInfo.Textures[0].Resolution+(quadX+1))
-			}
 		}
 		terrainMesh := uint32(len(doc.Meshes))
 		doc.Meshes = append(doc.Meshes, &gltf.Mesh{
 			Primitives: []*gltf.Primitive{{
-				Indices: gltf.Index(modeler.WriteIndices(doc, indices)),
+				Indices: gltf.Index(modeler.WriteIndices(doc, mesh.Indices[0])),
 				Attributes: gltf.Attribute{
-					gltf.POSITION: modeler.WritePosition(doc, vertices),
+					gltf.POSITION: modeler.WritePosition(doc, mesh.Positions),
 				},
 			}},
 		})

--- a/stingray/unit/unit.go
+++ b/stingray/unit/unit.go
@@ -1314,20 +1314,20 @@ func LoadInfo(mainR io.ReadSeeker) (*Info, error) {
 
 // idsToLoad contains the mesh IDs (=indices) of the meshes which should be loaded.
 // To load all meshes, pass a slice with value {0,1,...,info.NumMeshes-1}.
-func LoadMeshes(gpuR io.ReadSeeker, info *Info, idsToLoad []uint32) (map[uint32]Mesh, error) {
+func LoadMeshes(gpuR io.ReadSeeker, meshInfos []MeshInfo, meshLayouts []MeshLayout, idsToLoad []uint32) (map[uint32]Mesh, error) {
 	meshes := make(map[uint32]Mesh)
 	for _, id := range idsToLoad {
 		if _, ok := meshes[id]; ok {
 			continue
 		}
-		if int(id) > len(info.MeshInfos) {
-			return nil, fmt.Errorf("mesh ID (%v) is out of bounds of meshes (len=%v)", id, len(info.MeshInfos))
+		if int(id) > len(meshInfos) {
+			return nil, fmt.Errorf("mesh ID (%v) is out of bounds of meshes (len=%v)", id, len(meshInfos))
 		}
-		meshInfo := info.MeshInfos[id]
+		meshInfo := meshInfos[id]
 		if meshInfo.Header.LayoutIdx < 0 {
 			continue
 		}
-		layout := info.MeshLayouts[meshInfo.Header.LayoutIdx]
+		layout := meshLayouts[meshInfo.Header.LayoutIdx]
 		if len(meshInfo.Groups) > 0 && gpuR == nil {
 			return nil, errors.New("mesh group exists, but GPU resource data is nil")
 		}

--- a/stingray/unit/unit.go
+++ b/stingray/unit/unit.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/qmuntal/gltf"
@@ -784,6 +785,85 @@ func loadMesh(gpuR io.ReadSeeker, info MeshInfo, layout MeshLayout) (Mesh, error
 			mesh.Indices[grp] = append(mesh.Indices[grp], val+group.VertexOffset)
 		}
 	}
+	return mesh, nil
+}
+
+func LoadTerrain(terrainInfo TerrainInfo) (Mesh, error) {
+	if uint32(math.Sqrt(float64(len(terrainInfo.HeightmapData)/2))) != terrainInfo.Textures[0].Resolution {
+		return Mesh{}, fmt.Errorf("loading terrain: heightmap resolution mismatch")
+	}
+	terrainValues := make([]uint16, len(terrainInfo.HeightmapData)/2)
+	if _, err := binary.Decode(terrainInfo.HeightmapData, binary.LittleEndian, terrainValues); err != nil {
+		return Mesh{}, fmt.Errorf("loading terrain: failed to decode heightmap value: %v", err)
+	}
+
+	decompressHeight := func(value uint16, min, max float32) float32 {
+		percent := float32(value) / 65535.0
+		return (percent - 0.5) * (max - min)
+	}
+	vertices := make([][3]float32, 0)
+	indices := make([]uint32, 0)
+	uvs := make([][2]float32, 0)
+	normals := make([][3]float32, 0)
+	tangents := make([][3]float32, 0)
+	bitangents := make([][3]float32, 0)
+	up := mgl32.Vec3{0, 1, 0}
+	for y := range terrainInfo.Textures[0].Resolution {
+		for x := range terrainInfo.Textures[0].Resolution {
+			center := decompressHeight(terrainValues[y*terrainInfo.Textures[0].Resolution+x], terrainInfo.Min[2], terrainInfo.Max[2])
+			vertices = append(vertices, [3]float32{
+				(terrainInfo.Max[0]-terrainInfo.Min[0])*(float32(x)/float32(terrainInfo.Textures[0].Resolution)) + terrainInfo.Min[0],
+				center,
+				-((terrainInfo.Max[1]-terrainInfo.Min[1])*(float32(y)/float32(terrainInfo.Textures[0].Resolution)) + terrainInfo.Min[1]),
+			})
+			uvs = append(uvs, [2]float32{
+				float32(x) / float32(terrainInfo.Textures[0].Resolution),
+				float32(y) / float32(terrainInfo.Textures[0].Resolution),
+			})
+			// Central differencing for normals
+			var left, right, top, bottom float32 = center, center, center, center
+			if x > 0 {
+				left = decompressHeight(terrainValues[y*terrainInfo.Textures[0].Resolution+(x-1)], terrainInfo.Min[2], terrainInfo.Max[2])
+			}
+			if x < terrainInfo.Textures[0].Resolution-1 {
+				right = decompressHeight(terrainValues[y*terrainInfo.Textures[0].Resolution+(x+1)], terrainInfo.Min[2], terrainInfo.Max[2])
+			}
+			if y > 0 {
+				top = decompressHeight(terrainValues[(y-1)*terrainInfo.Textures[0].Resolution+x], terrainInfo.Min[2], terrainInfo.Max[2])
+			}
+			if y < terrainInfo.Textures[0].Resolution-1 {
+				bottom = decompressHeight(terrainValues[(y+1)*terrainInfo.Textures[0].Resolution+x], terrainInfo.Min[2], terrainInfo.Max[2])
+			}
+			normal := mgl32.Vec3{-2 * (right - left), 4, -2 * (bottom - top)}.Normalize()
+			normals = append(normals, normal)
+			tangent := normal.Cross(up)
+			if tangent.Len() > 0.0001 {
+				tangent = tangent.Normalize()
+			} else {
+				tangent = mgl32.Vec3{1, 0, 0}
+			}
+			bitangent := normal.Cross(tangent).Normalize()
+			tangents = append(tangents, tangent)
+			bitangents = append(bitangents, bitangent)
+		}
+	}
+
+	for quadY := range terrainInfo.Textures[0].Resolution - 1 {
+		for quadX := range terrainInfo.Textures[0].Resolution - 1 {
+			// face 0
+			indices = append(indices, (quadY)*terrainInfo.Textures[0].Resolution+(quadX), (quadY)*terrainInfo.Textures[0].Resolution+(quadX+1), (quadY+1)*terrainInfo.Textures[0].Resolution+(quadX+1))
+			// face 1
+			indices = append(indices, (quadY)*terrainInfo.Textures[0].Resolution+(quadX), (quadY+1)*terrainInfo.Textures[0].Resolution+(quadX+1), (quadY+1)*terrainInfo.Textures[0].Resolution+(quadX))
+		}
+	}
+
+	var mesh Mesh
+	mesh.Positions = vertices
+	mesh.Indices = [][]uint32{indices}
+	mesh.UVCoords = [][][2]float32{uvs}
+	mesh.Normals = normals
+	mesh.Tangents = tangents
+	mesh.Bitangents = bitangents
 	return mesh, nil
 }
 


### PR DESCRIPTION
This is another quality of life improvement to the GUI that shouldn't be locked behind game shader support. Terrain and geometry groups have been supported for export for a while but have not been previewable, which can be frustrating when you're looking through the files. This removes that limitation, and I probably should have done this a while ago rather than trying to completely overhaul the GUI's model loading in one massive PR