### PR TITLE
Search archives by armor set type

### DIFF
--- a/cmd/filediver-gui/main.go
+++ b/cmd/filediver-gui/main.go
@@ -857,9 +857,10 @@ func (a *guiApp) drawArchiveFilterWindow() {
 		a.archiveIDs,
 		&a.selectedArchives,
 		func(x stingray.Hash) string {
-			items := make([]string, 0, 3)
+			items := make([]string, 0, 4)
 			if as, ok := a.gameData.ArmorSets[x]; ok {
 				items = append(items, as.Name)
+				items = append(items, as.Type.String())
 			}
 			if name, ok := a.gameData.Hashes[x]; ok {
 				items = append(items, name)
@@ -870,7 +871,7 @@ func (a *guiApp) drawArchiveFilterWindow() {
 		func(x stingray.Hash, checked *bool) {
 			var label string
 			if armorSet, ok := a.gameData.ArmorSets[x]; ok {
-				label = x.String() + " (" + armorSet.Name + ")"
+				label = x.String() + " (" + armorSet.Name + " - " + armorSet.Type.String() + ")"
 			} else {
 				label, ok = a.gameData.Hashes[x]
 				if !ok {

--- a/cmd/tools/components/armor-set-json-dumper/dumper/dumper.go
+++ b/cmd/tools/components/armor-set-json-dumper/dumper/dumper.go
@@ -22,7 +22,7 @@ type SimplePiece struct {
 	DecalScalarFields string                            `json:"decal_scalar_fields"`
 	BaseData          string                            `json:"base_data"`
 	DecalSheet        string                            `json:"decal_sheet"`
-	ToneVariations    string                            `json:"tone_variations"`
+	ToneVariations    uint8                             `json:"tone_variations"`
 }
 
 type BodyType struct {
@@ -98,7 +98,7 @@ func Dump(a *app.App) {
 				DecalScalarFields: a.LookupHash(unitData.DecalScalarFields),
 				BaseData:          a.LookupHash(unitData.BaseData),
 				DecalSheet:        a.LookupHash(unitData.DecalSheet),
-				ToneVariations:    a.LookupHash(unitData.ToneVariations),
+				ToneVariations:    unitData.ToneVariations,
 			})
 		}
 		if len(anytype.Pieces) > 0 {

--- a/datalibrary/armor_sets.go
+++ b/datalibrary/armor_sets.go
@@ -116,7 +116,8 @@ type Piece struct {
 	DecalScalarFields stingray.Hash
 	BaseData          stingray.Hash
 	DecalSheet        stingray.Hash
-	ToneVariations    stingray.Hash
+	ToneVariations    uint8
+	_                 [7]uint8
 }
 
 type CustomizationKitBodyType uint32
@@ -233,7 +234,7 @@ type UnitData struct {
 	DecalScalarFields stingray.Hash
 	BaseData          stingray.Hash
 	DecalSheet        stingray.Hash
-	ToneVariations    stingray.Hash
+	ToneVariations    uint8
 }
 
 type ArmorSet struct {

--- a/hashes/cracked.txt
+++ b/hashes/cracked.txt
@@ -7249,6 +7249,8 @@ content/env_illuminate/cables/il_cables_010
 content/env_illuminate/cables/il_cables_011
 content/env_illuminate/cables/il_cables_012
 content/env_illuminate/cables/il_cables_013
+content/env_illuminate/cables/il_cables_huge_01
+content/env_illuminate/cables/il_cables_huge_02
 content/fac_bugs/cha_strider/cha_strider_gloom
 content/fac_helldivers/equipment/attachment/magazine/laser_rifle_charge_magazine
 content/fac_helldivers/equipment/attachment/magazine/smg_solvent_extended_magazine

--- a/hashes/hashes.txt
+++ b/hashes/hashes.txt
@@ -68807,6 +68807,8 @@ content/env_illuminate/cables/il_cables_010
 content/env_illuminate/cables/il_cables_011
 content/env_illuminate/cables/il_cables_012
 content/env_illuminate/cables/il_cables_013
+content/env_illuminate/cables/il_cables_huge_01
+content/env_illuminate/cables/il_cables_huge_02
 content/env_illuminate/corpses/il_corpse_lyingdown_01
 content/env_illuminate/corpses/il_corpse_pile_01
 content/env_illuminate/corpses/il_corpse_pile_large_01
@@ -73831,9 +73833,9 @@ content/objectives/obj_illuminate/il_mothership/textures/il_mothership_nar
 content/objectives/obj_illuminate/il_portal_batteries/il_portal_batteries
 content/objectives/obj_illuminate/il_raise_building_01/il_gate
 content/objectives/obj_illuminate/il_raise_building_01/il_gate_shield
-content/objectives/obj_illuminate/il_raise_building_01/il_rounded_shield
 content/objectives/obj_illuminate/il_raise_building_01/il_raise_building_02
 content/objectives/obj_illuminate/il_raise_building_01/il_raise_building_02_shield
+content/objectives/obj_illuminate/il_raise_building_01/il_rounded_shield
 content/objectives/obj_illuminate/il_sarcophagus/il_sarcophagus
 content/objectives/obj_illuminate/il_stratagem_scrambler/il_scrambler_battery
 content/objectives/obj_illuminate/il_stratagem_scrambler/il_stratagem_scrambler


### PR DESCRIPTION
Adds the armor set type - Armor, Helmet, Cape - to the search terms in the archive filter window, so searching for types of archives is easier

Also adds a couple of hashes