### PR TITLE
Fix armor set extraction

### DIFF
--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -672,7 +672,10 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 		}
 	} else {
 		for _, armorSet := range armorSets {
-			for _, meta := range armorSet.UnitMetadata {
+			for hash, meta := range armorSet.UnitMetadata {
+				if armorSet.Type != datalib.KitCape && hash != ctx.FileID().Name {
+					continue
+				}
 				tmp, err := AddMaterials(ctx, doc, imgOpts, unitInfo, &meta)
 				if err != nil {
 					return err


### PR DESCRIPTION
The cape shader changes accidentally caused the armor set extraction process to simply choose a random (usually incorrect) texture for each armor piece. This bugfix makes sure that the armor piece we're using is the same as the file thats currently being extracted