### PR TITLE
Fix archive loading for the latest update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ filediver-gui-windows.exe
 filediver-gui.exe
 filediver-cli.exe
 /rsrc_windows_*.syso
+/bundles.dsaa

--- a/patterns/dsar.hexpat
+++ b/patterns/dsar.hexpat
@@ -20,7 +20,7 @@ struct Chunk {
     CompressionType compression;
     ResourceType type;
     padding[6];
-    u8 data[compressed_size] @ compressed_offset;
+    //u8 data[compressed_size] @ compressed_offset; // commented for perf
 };
 
 struct DSAR {

--- a/stingray/archive.go
+++ b/stingray/archive.go
@@ -107,11 +107,30 @@ type Archive struct {
 	Files  []FileData
 }
 
+// Gets the archive size (excluding main data; meaning size of header, type info and file info)
+// by reading only the header.
+func LoadArchiveSize(mainR io.Reader) (int, error) {
+	r := bufio.NewReader(mainR)
+
+	var hdr HeaderData
+	if err := binary.Read(r, binary.LittleEndian, &hdr); err != nil {
+		return -1, err
+	}
+
+	if hdr.MagicNum != [4]byte{0x11, 0x00, 0x00, 0xF0} {
+		return -1, errors.New("invalid magic number")
+	}
+
+	return binary.Size(HeaderData{}) +
+		binary.Size(TypeData{})*int(hdr.NumTypes) +
+		binary.Size(FileData{})*int(hdr.NumFiles), nil
+}
+
 func LoadArchive(mainFilename string, mainR io.Reader) (*Archive, error) {
 	r := bufio.NewReader(mainR)
 	id, err := ParseHash(mainFilename)
 	if err != nil {
-		return nil, fmt.Errorf("parsing archive main filename: %w", err)
+		return nil, fmt.Errorf("parsing archive main, filename: %w", err)
 	}
 
 	var hdr HeaderData

--- a/stingray/slim_edition.go
+++ b/stingray/slim_edition.go
@@ -372,10 +372,15 @@ func openDataDirSlim(ctx context.Context, dirPath string, onProgress func(curr, 
 		}
 		var data bytes.Buffer
 		writeEntryToBuffer := func(data *bytes.Buffer, entIdx int) error {
-			ent := arItem.Entries[entIdx]
-			bundle := bundles[ent.BundleIndex]
+			entry := arItem.Entries[entIdx]
+			entrySize := arItem.Header.Size - uint64(entry.ArchiveOffset)
+			if entIdx+1 < len(arItem.Entries) {
+				nextEntry := arItem.Entries[entIdx+1]
+				entrySize = uint64(nextEntry.ArchiveOffset) - uint64(entry.ArchiveOffset)
+			}
+			bundle := bundles[entry.BundleIndex]
 			dsar := bundle.DSAR
-			chkIdx, err := findDSARChunkForDSAAEntry(dsar, ent)
+			chkIdx, err := findDSARChunkForDSAAEntry(dsar, entry)
 			if err != nil {
 				return err
 			}
@@ -383,12 +388,20 @@ func openDataDirSlim(ctx context.Context, dirPath string, onProgress func(curr, 
 			if err != nil {
 				return fmt.Errorf("opening bundle %s: %w", bundle.Filename, err)
 			}
-			chunkData, err := ReadDSARChunkData(f, dsar.Chunks[chkIdx])
-			f.Close()
-			if err != nil {
-				return fmt.Errorf("reading DSAR chunk %d in %s: %w", chkIdx, bundle.Filename, err)
+			defer f.Close()
+			writtenEntrySize := uint64(0)
+			for writtenEntrySize < entrySize {
+				chunkData, err := ReadDSARChunkData(f, dsar.Chunks[chkIdx])
+				if err != nil {
+					return fmt.Errorf("reading DSAR chunk %d in %s: %w", chkIdx, bundle.Filename, err)
+				}
+				written, err := data.Write(chunkData)
+				if err != nil {
+					return fmt.Errorf("writing DSAR chunk %d in %s to buffer: %w", chkIdx, bundle.Filename, err)
+				}
+				writtenEntrySize += uint64(written)
+				chkIdx += 1
 			}
-			data.Write(chunkData)
 			return nil
 		}
 		if err := writeEntryToBuffer(&data, 0); err != nil {

--- a/stingray/slim_edition.go
+++ b/stingray/slim_edition.go
@@ -268,7 +268,7 @@ func loadDSAAFromBundlesNXA(bundlesNXAPath string) (_ *DSAA, err error) {
 	return dsaa, err
 }
 
-func findDSARChunkForDSAAEntry(dsar *DSARStructure, ent DSAAEntry) (entryIndex int, err error) {
+func findDSARChunkForDSAAEntry(dsar *DSARStructure, ent DSAAEntry) (chunkIndex int, err error) {
 	idx, ok := slices.BinarySearchFunc(dsar.Chunks, ent.UncompressedBundleOffset, func(chk DSARChunk, uncompOffs uint32) int {
 		return cmp.Compare(chk.UncompressedOffset, uint64(uncompOffs))
 	})
@@ -370,25 +370,42 @@ func openDataDirSlim(ctx context.Context, dirPath string, onProgress func(curr, 
 		if len(arItem.Entries) == 0 {
 			return nil, fmt.Errorf("expected DSAA archive to have at least one entry")
 		}
-		ent := arItem.Entries[0]
-		bundle := bundles[ent.BundleIndex]
-		dsar := bundle.DSAR
-		chkIdx, err := findDSARChunkForDSAAEntry(dsar, ent)
-		if err != nil {
+		var data bytes.Buffer
+		writeEntryToBuffer := func(data *bytes.Buffer, entIdx int) error {
+			ent := arItem.Entries[entIdx]
+			bundle := bundles[ent.BundleIndex]
+			dsar := bundle.DSAR
+			chkIdx, err := findDSARChunkForDSAAEntry(dsar, ent)
+			if err != nil {
+				return err
+			}
+			f, err := os.Open(filepath.Join(dirPath, bundle.Filename))
+			if err != nil {
+				return fmt.Errorf("opening bundle %s: %w", bundle.Filename, err)
+			}
+			chunkData, err := ReadDSARChunkData(f, dsar.Chunks[chkIdx])
+			f.Close()
+			if err != nil {
+				return fmt.Errorf("reading DSAR chunk %d in %s: %w", chkIdx, bundle.Filename, err)
+			}
+			data.Write(chunkData)
+			return nil
+		}
+		if err := writeEntryToBuffer(&data, 0); err != nil {
 			return nil, err
 		}
-		f, err := os.Open(filepath.Join(dirPath, bundle.Filename))
+		arSize, err := LoadArchiveSize(bytes.NewReader(data.Bytes()))
 		if err != nil {
-			return nil, fmt.Errorf("opening bundle %s: %w", bundle.Filename, err)
+			return nil, fmt.Errorf("loading size of archive %s: %w", arItem.Filename, err)
 		}
-		data, err := ReadDSARChunkData(f, dsar.Chunks[chkIdx])
-		f.Close()
-		if err != nil {
-			return nil, fmt.Errorf("reading DSAR chunk %d in %s: %w", chkIdx, bundle.Filename, err)
+		for i := 1; i < len(arItem.Entries) && data.Len() < arSize; i++ {
+			if err := writeEntryToBuffer(&data, i); err != nil {
+				return nil, err
+			}
 		}
-		archive, err := LoadArchive(arItem.Filename, bytes.NewReader(data))
+		archive, err := LoadArchive(arItem.Filename, bytes.NewReader(data.Bytes()))
 		if err != nil {
-			return nil, fmt.Errorf("loading archive %s from %s: %w", arItem.Filename, bundle.Filename, err)
+			return nil, fmt.Errorf("loading archive %s: %w", arItem.Filename, err)
 		}
 		addArchive(archive)
 	}


### PR DESCRIPTION
This completely resolves the problems we were having with `18235e0c9ec0e636` - the only thing missing from the first pass of changes was that DSAA archive entries could be split across multiple DSAR chunks