### PR TITLE
docs: add Related Resources section (Helldivers 2 Guides companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The program is called "filediver.exe" (or just "filediver" on Linux). See [usage
 ## Links
 - [HD 2 Archive Labelling](https://docs.google.com/spreadsheets/d/1oQys_OI5DWou4GeRE3mW56j7BIi4M7KftBIPAl1ULFw) (IDs can be used with -t option)
 - [Helldivers Archive Discord server](https://discord.gg/y7P38h2B9Q)
+- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.
 
 ## Credits
 - Filediver icon by @gobashroom on [HD2 Modding Discord](https://discord.gg/helldiversmodding)


### PR DESCRIPTION
Thanks for building filediver — asset tooling pairs well with a player-facing Helldivers 2 guide site.

This PR adds a single link to the existing Related/Resources section pointing to a companion player-facing guide site:

- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `append_to:## Links`.)_