### PR TITLE
Remove postprocessing of base_data textures

### DIFF
--- a/extractor/material/extractor.go
+++ b/extractor/material/extractor.go
@@ -1042,6 +1042,8 @@ func AddMaterial(ctx *extractor.Context, mat *material.Material, doc *gltf.Docum
 				usedTextures[texUsageStr] = index
 			}
 			albedoPostProcess = postProcessToOpaque
+		case "base_data":
+			fallthrough
 		case "normal_specular_ao":
 			// GLTF normals will look wonky, but our own material will be able to use the specular+ao in this map
 			// in blender
@@ -1056,8 +1058,6 @@ func AddMaterial(ctx *extractor.Context, mat *material.Material, doc *gltf.Docum
 		case "covering_normal":
 			fallthrough
 		case "NAC":
-			fallthrough
-		case "base_data":
 			useNormalMapAlphaSetting, ok := mat.Settings[stingray.Sum("use_normal_map_alpha").Thin()]
 			if ok && useNormalMapAlphaSetting[0] == 0 {
 				normalPostProcess = postProcessReconstructNormalZ


### PR DESCRIPTION
Base data textures actually contain data the accurate shader uses to improve the visuals of armor, so we should not be post processing them on export.

Before:
<img width="1012" height="1080" alt="image" src="https://github.com/user-attachments/assets/acfe15c8-1687-4d44-8dcb-5189fc458433" />

After:
<img width="740" height="901" alt="image" src="https://github.com/user-attachments/assets/5089bf62-e72f-446f-a86b-88e105c6e7de" />
