### PR TITLE
Use planet name to apply asset grading/overrides, add gui color grading preview on speedtrees

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -8,12 +8,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
+
+	"golang.org/x/text/cases"
+	language_lib "golang.org/x/text/language"
 
 	"github.com/gobwas/glob"
 	"github.com/qmuntal/gltf"
@@ -126,10 +130,22 @@ type App struct {
 	WeaponPaintSchemes []datalib.WeaponCustomizableItem
 	AttachmentSlots    map[stingray.Hash]enum.WeaponCustomizationSlot
 	EntityVarMapping   shading_environment.ShadingEnvironmentEntityToShaderMapping
+	Planets            map[string]datalib.PlanetData
+	PlanetOverrides    datalib.PlanetOverridesMap
+	AssetOverrides     *map[stingray.FileID]stingray.FileID
 	DataDir            *stingray.DataDir
+	Language           stingray.ThinHash
 	LanguageMap        map[uint32]string
 	Metadata           map[stingray.FileID]FileMetadata
 	GameBuildInfo      *ah_bin.BuildInfo
+}
+
+func getLowerCaser(language stingray.ThinHash) cases.Caser {
+	languageTag, contains := stingray_strings.LanguageHashToLanguageTag[language]
+	if !contains {
+		languageTag = language_lib.English
+	}
+	return cases.Lower(languageTag)
 }
 
 // Automatically gets most wwise-related hashes by reading the game files
@@ -503,6 +519,28 @@ func OpenGameDir(ctx context.Context, gameDir string, hashStrings []string, thin
 	if err != nil {
 		return nil, fmt.Errorf("error loading weapon attachment slots: %v", err)
 	}
+	planetData, err := datalib.LoadPlanetData(lookupHash, lookupThinHash, lookupString)
+	if err != nil {
+		return nil, fmt.Errorf("error loading planet data: %v", err)
+	}
+	planetMap := make(map[string]datalib.PlanetData)
+	caser := getLowerCaser(language)
+	for _, planet := range planetData {
+		if planet.PlanetNameLoc == "" {
+			continue
+		}
+		planetNameLower := caser.String(planet.PlanetNameLoc)
+		planetMap[planetNameLower] = planet
+	}
+	planetOverrides, err := datalib.LoadPlanetOverrideSettings(lookupHash, lookupThinHash, lookupString)
+	if err != nil {
+		return nil, fmt.Errorf("error loading planet overrides data: %v", err)
+	}
+	planetOverridesMap := make(datalib.PlanetOverridesMap)
+	for _, override := range planetOverrides {
+		maps.Copy(planetOverridesMap, override.ToMap())
+	}
+	var assetOverrides map[stingray.FileID]stingray.FileID
 
 	return &App{
 		Hashes:             hashesMap,
@@ -512,7 +550,11 @@ func OpenGameDir(ctx context.Context, gameDir string, hashStrings []string, thin
 		WeaponPaintSchemes: weaponPaintSchemes,
 		AttachmentSlots:    attachmentSlots,
 		EntityVarMapping:   entityVarMapping,
+		Planets:            planetMap,
+		PlanetOverrides:    planetOverridesMap,
+		AssetOverrides:     &assetOverrides,
 		DataDir:            dataDir,
+		Language:           language,
 		LanguageMap:        mapping,
 		Metadata:           getFileMetadata(dataDir),
 		GameBuildInfo:      buildInfo,
@@ -694,6 +736,30 @@ func (a *App) LookupString(stringId uint32) string {
 	return strconv.FormatUint(uint64(stringId), 10)
 }
 
+func (a *App) UpdateAssetOverrides(planetName string, city bool) *datalib.PlanetData {
+	caser := getLowerCaser(a.Language)
+	planetName = caser.String(planetName)
+	var planet datalib.PlanetData
+	var contains bool
+	if planet, contains = a.Planets[planetName]; !contains {
+		*a.AssetOverrides = nil
+		return nil
+	}
+	assetOverrides := make(map[stingray.FileID]stingray.FileID)
+	for _, region := range planet.ResourceRegionOverrides {
+		if !city && region.RegionFlag == enum.RegionFlag_City {
+			continue
+		}
+		regionOverrides, contains := a.PlanetOverrides[region.ID]
+		if !contains {
+			continue
+		}
+		maps.Copy(assetOverrides, regionOverrides)
+	}
+	*a.AssetOverrides = assetOverrides
+	return &planet
+}
+
 func getSourceExtractFunc(extrCfg appconfig.Config, typ string) (extr extractor.ExtractFunc) {
 	switch extrCfg.Raw.Format {
 	case "main":
@@ -838,6 +904,14 @@ func (a *App) ExtractFile(ctx context.Context, id stingray.FileID, outDir string
 		},
 		statusf,
 	)
+
+	caser := getLowerCaser(a.Language)
+	planetName := caser.String(extrCfg.Planet.Name)
+	if planet, contains := a.Planets[planetName]; contains {
+		a.UpdateAssetOverrides(planetName, extrCfg.Planet.City)
+		extrCtx = extrCtx.WithAssetOverrides(*a.AssetOverrides).WithColorGrading(planet.PaletteGroupLowland.AssetGrading)
+	}
+
 	err := extr(extrCtx)
 	outFiles := getOutFiles()
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -436,6 +436,17 @@ func LoadAttachmentSlots(dataDir *stingray.DataDir, languageMap map[uint32]strin
 	return result, nil
 }
 
+func LoadEntityVariableMappings(dataDir *stingray.DataDir) (entityVarMapping shading_environment.ShadingEnvironmentEntityToShaderMapping) {
+	shadingEnvironmentMappings, err := shading_environment.LoadMappingsFromDataDir(dataDir)
+	if err == nil {
+		entityVarMapping = make(shading_environment.ShadingEnvironmentEntityToShaderMapping)
+		for _, mapping := range shadingEnvironmentMappings {
+			maps.Copy(entityVarMapping, mapping.ToEntityMap())
+		}
+	}
+	return
+}
+
 // Open game dir and read metadata.
 func OpenGameDir(ctx context.Context, gameDir string, hashStrings []string, thinhashes []string, language stingray.ThinHash, onProgress func(curr, total int)) (*App, error) {
 	dataDir, err := stingray.OpenDataDir(ctx, filepath.Join(gameDir, "data"), onProgress)
@@ -464,15 +475,6 @@ func OpenGameDir(ctx context.Context, gameDir string, hashStrings []string, thin
 	buildInfo, err := ah_bin.LoadFromDataDir(dataDir)
 	if err != nil && err != ah_bin.NotFound {
 		return nil, fmt.Errorf("error loading game build info: %v", err)
-	}
-
-	var entityVarMapping shading_environment.ShadingEnvironmentEntityToShaderMapping
-	shadingEnvironmentMappings, err := shading_environment.LoadMappingsFromDataDir(dataDir)
-	if err == nil {
-		entityVarMapping = make(shading_environment.ShadingEnvironmentEntityToShaderMapping)
-		for _, mapping := range shadingEnvironmentMappings {
-			entityVarMapping = mapping.ToEntityMap(entityVarMapping)
-		}
 	}
 
 	lookupHash := func(hash stingray.Hash) string {
@@ -519,6 +521,9 @@ func OpenGameDir(ctx context.Context, gameDir string, hashStrings []string, thin
 	if err != nil {
 		return nil, fmt.Errorf("error loading weapon attachment slots: %v", err)
 	}
+
+	entityVarMapping := LoadEntityVariableMappings(dataDir)
+
 	planetData, err := datalib.LoadPlanetData(lookupHash, lookupThinHash, lookupString)
 	if err != nil {
 		return nil, fmt.Errorf("error loading planet data: %v", err)
@@ -736,13 +741,20 @@ func (a *App) LookupString(stringId uint32) string {
 	return strconv.FormatUint(uint64(stringId), 10)
 }
 
-func (a *App) UpdateAssetOverrides(planetName string, city bool) *datalib.PlanetData {
+func (a *App) GetPlanet(planetName string, city bool) *datalib.PlanetData {
 	caser := getLowerCaser(a.Language)
 	planetName = caser.String(planetName)
 	var planet datalib.PlanetData
 	var contains bool
 	if planet, contains = a.Planets[planetName]; !contains {
-		*a.AssetOverrides = nil
+		return nil
+	}
+	return &planet
+}
+
+func (a *App) GetAssetOverrides(planetName string, city bool) map[stingray.FileID]stingray.FileID {
+	planet := a.GetPlanet(planetName, city)
+	if planet == nil {
 		return nil
 	}
 	assetOverrides := make(map[stingray.FileID]stingray.FileID)
@@ -756,8 +768,12 @@ func (a *App) UpdateAssetOverrides(planetName string, city bool) *datalib.Planet
 		}
 		maps.Copy(assetOverrides, regionOverrides)
 	}
+	return assetOverrides
+}
+
+func (a *App) UpdateAssetOverrides(planetName string, city bool) {
+	assetOverrides := a.GetAssetOverrides(planetName, city)
 	*a.AssetOverrides = assetOverrides
-	return &planet
 }
 
 func getSourceExtractFunc(extrCfg appconfig.Config, typ string) (extr extractor.ExtractFunc) {

--- a/app/appconfig/appconfig.go
+++ b/app/appconfig/appconfig.go
@@ -97,7 +97,7 @@ type Config struct {
 		Format string `cfg:"options=separate,combined,main,stream,gpu help='how to handle the different file sub-types (each file may have a main, stream and GPU file)'"`
 	} `cfg:"help='applies to any file without an available extractor or \"raw\" as the selected format'"`
 	Planet struct {
-		Name string `cfg:"options=test help='Name of planet to use for asset customization'"`
+		Name string `cfg:"help='Name of planet to use for asset customization' truncate"`
 		City bool   `cfg:"help='Use city-specific overrides'"`
 	} `cfg:"help='Apply overrides from a specific planet to the exported assets'"`
 }

--- a/app/appconfig/appconfig.go
+++ b/app/appconfig/appconfig.go
@@ -69,8 +69,7 @@ type Config struct {
 		Format string `cfg:"options=json,raw"`
 	} `cfg:"tags=t:entity,t:shading_environment_mapping,t:shading_environment help='Shading environment configuration file export settings'"`
 	SpeedTree struct {
-		Format       string `cfg:"options=model,json,raw"`
-		ColorGrading string `cfg:"tags=advanced help='entity file to use for color grading lut'"`
+		Format string `cfg:"options=model,json,raw"`
 	} `cfg:"tags=t:speedtree help='Tree model export format'"`
 	XAML struct {
 		Format string `cfg:"options=svg,xaml,raw"`
@@ -78,6 +77,10 @@ type Config struct {
 	Raw struct {
 		Format string `cfg:"options=separate,combined,main,stream,gpu help='how to handle the different file sub-types (each file may have a main, stream and GPU file)'"`
 	} `cfg:"help='applies to any file without an available extractor or \"raw\" as the selected format'"`
+	Planet struct {
+		Name string `cfg:"help='Name of planet to use for asset customization'"`
+		City bool   `cfg:"help='Use city-specific overrides'"`
+	} `cfg:"help='Apply overrides from a specific planet to the exported assets'"`
 }
 
 // Config must be comparable

--- a/app/appconfig/appconfig.go
+++ b/app/appconfig/appconfig.go
@@ -1,6 +1,9 @@
 package appconfig
 
 import (
+	"bufio"
+	"bytes"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"io/fs"
@@ -11,6 +14,22 @@ import (
 
 	"github.com/xypwn/filediver/config"
 )
+
+//go:embed planets.txt
+var planets []byte
+
+var ConfigFields *config.FieldSet
+
+func init() {
+	ConfigFields = config.MustFields(Config{})
+	var _ = GetTypeFormats(Config{}) // config sanity check (see GetTypeFormats)
+
+	planetsScanner := bufio.NewScanner(bytes.NewReader(planets))
+	ConfigFields.ByName["Planet.Name"].Options = []string{"<none>"}
+	for planetsScanner.Scan() {
+		ConfigFields.ByName["Planet.Name"].Options = append(ConfigFields.ByName["Planet.Name"].Options, planetsScanner.Text())
+	}
+}
 
 // This is the central config structure used in the GUI
 // and CLI.
@@ -78,7 +97,7 @@ type Config struct {
 		Format string `cfg:"options=separate,combined,main,stream,gpu help='how to handle the different file sub-types (each file may have a main, stream and GPU file)'"`
 	} `cfg:"help='applies to any file without an available extractor or \"raw\" as the selected format'"`
 	Planet struct {
-		Name string `cfg:"help='Name of planet to use for asset customization'"`
+		Name string `cfg:"options=test help='Name of planet to use for asset customization'"`
 		City bool   `cfg:"help='Use city-specific overrides'"`
 	} `cfg:"help='Apply overrides from a specific planet to the exported assets'"`
 }
@@ -137,9 +156,6 @@ var Extractable = map[string]bool{
 	"otf":            true,
 	"xaml":           true,
 }
-
-var ConfigFields = config.MustFields(Config{})
-var _ = GetTypeFormats(Config{}) // config sanity check (see GetTypeFormats)
 
 // GetTypeFormats maps each affected type
 // (denoted by t:<type> tag in config struct) to

--- a/app/appconfig/generate.go
+++ b/app/appconfig/generate.go
@@ -1,0 +1,3 @@
+package appconfig
+
+//go:generate go run github.com/xypwn/filediver/app/appconfig/generate/

--- a/app/appconfig/generate/main.go
+++ b/app/appconfig/generate/main.go
@@ -37,7 +37,7 @@ func main() {
 	argp := argparse.NewParser("planet-name-generator", "", &argparse.ParserConfig{
 		DisableDefaultShowHelp: true,
 	})
-	prt, app := fdtools.InitWithLanguage(argp, "English (US)")
+	prt, app := fdtools.Init(argp)
 	planetNames := generatePlanetNames(app)
 	output, err := os.Create("planets.txt")
 	if err != nil {

--- a/app/appconfig/generate/main.go
+++ b/app/appconfig/generate/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"maps"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/hellflame/argparse"
+	"github.com/xypwn/filediver/app"
+	"github.com/xypwn/filediver/cmd/tools/fdtools-common"
+	stingray_strings "github.com/xypwn/filediver/stingray/strings"
+	"golang.org/x/text/cases"
+)
+
+func generatePlanetNames(a *app.App) []string {
+	hasAlpha := regexp.MustCompile("[a-zÀ-Þ]").MatchString
+	titleCaser := cases.Title(stingray_strings.LanguageHashToLanguageTag[a.Language])
+	romanNumeral := regexp.MustCompile(`(?i)(\pZ|\pP)M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})\pZ?`)
+	planetNames := slices.Collect(maps.Keys(a.Planets))
+	slices.Sort(planetNames)
+	for i := 0; i < len(planetNames); {
+		if !hasAlpha(planetNames[i]) || (i+1 < len(planetNames) && planetNames[i] == planetNames[i+1]) {
+			planetNames = append(planetNames[:i], planetNames[i+1:]...)
+			continue
+		}
+		planetNames[i] = titleCaser.String(planetNames[i])
+		planetNames[i] = romanNumeral.ReplaceAllStringFunc(planetNames[i], strings.ToUpper)
+		i++
+	}
+
+	return planetNames
+}
+
+func main() {
+	argp := argparse.NewParser("planet-name-generator", "", &argparse.ParserConfig{
+		DisableDefaultShowHelp: true,
+	})
+	prt, app := fdtools.InitWithLanguage(argp, "English (US)")
+	planetNames := generatePlanetNames(app)
+	output, err := os.Create("planets.txt")
+	if err != nil {
+		prt.Fatalf("Failed to create output file: %v", err)
+	}
+	defer output.Close()
+
+	for _, name := range planetNames {
+		output.WriteString(name + "\n")
+	}
+}

--- a/app/appconfig/planets.txt
+++ b/app/appconfig/planets.txt
@@ -1,0 +1,390 @@
+Acamar IV
+Achernar Secundus
+Achird III
+Acrab XI
+Acrux IX
+Acubens Prime
+Adhafera Secundus
+Adhara
+Adrenal 8
+Aesir Pass
+Afoyay Bay
+Ain-5
+Aladfar CXI
+Alairt III
+Alamak VII
+Alaraph
+Alathfar XI
+Alderidge Cove
+Almina IV
+Alta V
+Amittere
+Andar
+Andwell
+Angel's Venture
+Annihilated System
+Anomalous System
+Aquila XXXII
+Arability
+Argentis
+Arkturus
+Arlia
+Asperoth Prime
+Atrama
+Aurora Bay
+Auspice
+Avila
+Azterra
+Azur Secundus
+Baldrick Prime
+Ballot
+Bankability
+Barabos
+Bashyr
+Basquine VIII
+Bekvam III
+Bellatrix
+Bicep
+Big Rock
+Blistica
+Bohus
+Bore Rock
+Borea
+Botein
+Brilliance
+Brink-2
+Bunda Secundus
+Calefactoria
+Calypso
+Canopus
+Caph
+Caramoor
+Castor
+Cerberus IIIc
+Chara
+Charbal-VII
+Charon Prime
+Choepessa IV
+Choohe
+Chort Bay
+Cirrus
+Civility
+Claorell
+Clasa
+Columbidae
+Concealed System
+Conlon Colony
+Crimsica
+Crucible
+Curia
+Cursa
+Cyberstan
+Cygnia III
+Darius II
+Darrowsport
+Deecon
+Defensible
+Demiurg
+Deneb Secundus
+Dev_01
+Dev_02
+Dev_03
+Dev_04
+Dev_05
+Dev_06
+Dev_07
+Dev_08
+Dev_09
+Diaspora X
+Diluvia
+Dolph
+Doublet II
+Draupnir
+Duma Tyr
+Dunoonia
+Durgen
+E-710-Rich System
+East Iridium Trading Bay
+Effluvia
+Electra Bay
+Eligible
+Elysian Meadows
+Embold
+Emeria
+Emorath
+Enuliale
+Epsilon Phoencis VI
+Erata Prime
+Errant
+Erson Sands
+Esker
+Estanu
+Eukoria
+Euphoria III
+Family-Friend
+Fenmire
+Fenrir III
+Fledge
+Fori Prime
+Fornskogur II
+Fort Justice
+Fort Sanctuary
+Fort Union
+Frakeneeria
+Freedom Peak
+Fronteria
+Fury
+Gacrux
+Gaellivare
+Gar Haren
+Gatria
+Gemma
+Gemstone Bluffs
+Generation
+Genesis Prime
+Gile
+Grafmere
+Grand Errant
+Gunnar
+Gunvald
+Hadar
+Haka
+Haldus
+Halies Port
+Hammarby
+Heeth
+Hellmire
+Herthon Secundus
+Hesoe Prime
+Hett
+Heze Bay
+Hopeful
+Hort
+Husaria
+Hydrobius
+Hydrofall Prime
+Igla
+Ilduna Prime
+Imber
+Inari
+Ingmar
+Iridica
+Iro
+Irulta
+Ivis
+Julheim
+K
+Karlia
+Karon Bay
+Keid
+Kelvinor
+Kerth Secundus
+Khandark
+Kharst
+Kirrik
+Klaka 5
+Klen Dahth II
+Kneth Port
+Korv
+Krakabos
+Krakatwo
+Kraz
+Kuma
+Kuper
+Lamb's Patch
+Lambast
+Lastofe
+Leng Secundus
+Lesath
+Liberty Ridge
+Lindome
+Link B
+Logisticae
+Lone
+Luxuriant
+Lynx Lynx
+Maia
+Malevelon Creek
+Mandilaria
+Mantes
+Marfark
+Marre IV
+Martale
+Martyr's Bay
+Mastia
+Matar Bay
+Maw
+Meissa
+Mekbuda
+Menkent
+Merak
+Merga IV
+Meridia
+Meridian IIa
+Midasburg
+Minchir
+Minerva
+Mintoria
+Miqé
+Mog
+Momo-1
+Monheim
+Moradesh
+Mordia 9
+Mort
+Mortax Prime
+Mox
+Myradesh
+Myrium
+Mönsterås II
+Nabatea Secundus
+Nascence
+Navi VII
+New Haven
+New Insight
+New Kiruna
+New Stockholm
+New Wisdom
+Nibiru
+Nivel 43
+Nosser
+Nublaria I
+Oasis
+Obari
+Okul VI
+Omicron
+Oroth
+Oshaune
+Oslo Station
+Ostehovel
+Osupsam
+Otur
+Outpost 32
+Overgoe Prime
+Pandion-XXIV
+Parsh
+Partion
+Pathfinder V
+Payong
+Peacock
+Pennybridge
+Penta
+Peony
+Pestis
+Phact Bay
+Phantom 1
+Pherkad Secundus
+Piea
+Pilen V
+Pine Tar
+Pioneer II
+Pipionem
+Polaris Prime
+Pollux 31
+Prasa
+Primordia
+Probability
+Probare
+Propus
+Prosperity Falls
+Providence
+Pöpli IX
+Ras Algethi
+Rasp
+Ratch
+Raysting
+Rd-4
+Reaf
+Regnus
+Resilience
+Retributary
+Rirga Bay
+Rogue 5
+Ruined System
+Sammelsurium
+Sangis
+Satellaria
+Scutum Canis Lupus
+Seasse
+Senge 23
+Serendipity XI
+Setia
+Seyshel Beach
+Shallus
+Shelt
+Shete
+Shirahama
+Siemnot
+Sirius
+Sirius II
+Skaash
+Skat Bay
+Skitter
+Slif
+Socorro III
+Solghast
+Spherion
+Spoyle
+Stolthet
+Stor Tha Prime
+Stout
+Sulfura
+Super Earth
+Superioria LV
+Svitjod
+Tandem
+Tarsh
+Termadon
+Terrek
+Terrene
+The Bug Quarantine
+The Weir
+Thrash IV
+Tibit
+Tien Kwan
+Tor E
+Trandor
+Troost
+Turing
+Ubanea
+Undisclosed Location
+Uninhabitable System
+Unknown System
+Unmapped System
+Unregistered System
+Urectem
+Ursica XI
+Ustotu
+Vacca
+Valgaard
+Valmox
+Vandalon IV
+Varylia 5
+Vega Bay
+Veil
+Veld
+Vernen Wells
+Vindemitarix Prime
+Vinge
+Viridia Prime
+Vital System
+Vog-Sojoth
+Volterra
+Wasat
+Watchdog 5
+Wayward
+Wezen
+Widow's Harbor
+Wile
+Wilford Station
+Worthy I
+Wraith
+X-45
+Yed Prior
+Zagon Prime
+Zea Rugosia
+Zefia
+Zegema Paradise
+Zosma
+Zygos
+Zzaniah Prime

--- a/cmd/filediver-cli/cli.go
+++ b/cmd/filediver-cli/cli.go
@@ -63,17 +63,7 @@ func cliHandleArgs(configStruct any, addExtraArgs func(argp *argparse.Parser)) (
 		addExtraArgs(argp)
 	}
 
-	fs, err := config.Fields(configStruct)
-	if err != nil {
-		return nil, false, err
-	}
-	if showAdvancedHelp {
-		fs = appconfig.ConfigFields
-	} else {
-		shownOptions := 4
-		fs.ByName["Planet.Name"].Options = append(appconfig.ConfigFields.ByName["Planet.Name"].Options[:shownOptions], fmt.Sprintf("%v... [Use --help-all to show all %v options]", appconfig.ConfigFields.ByName["Planet.Name"].Options[shownOptions], len(appconfig.ConfigFields.ByName["Planet.Name"].Options)))
-	}
-
+	fs := appconfig.ConfigFields
 	formatFieldName := func(field string) string {
 		return "--" + strcase.ToKebab(field)
 	}
@@ -115,7 +105,7 @@ func cliHandleArgs(configStruct any, addExtraArgs func(argp *argparse.Parser)) (
 		if !isAdvanced && categoryHelp != "" {
 			opts.Group = opts.Group + " (" + categoryHelp + ")"
 		}
-		opts.HintInfo = fs.FieldFormatHint(field.Name, formatFieldName)
+		opts.HintInfo = fs.FieldFormatHint(field.Name, formatFieldName, showAdvancedHelp)
 		var short string
 		if field.Short != 0 {
 			short = string(field.Short)

--- a/cmd/filediver-cli/cli.go
+++ b/cmd/filediver-cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/jwalton/go-supportscolor"
 
+	"github.com/xypwn/filediver/app/appconfig"
 	"github.com/xypwn/filediver/config"
 )
 
@@ -65,6 +66,12 @@ func cliHandleArgs(configStruct any, addExtraArgs func(argp *argparse.Parser)) (
 	fs, err := config.Fields(configStruct)
 	if err != nil {
 		return nil, false, err
+	}
+	if showAdvancedHelp {
+		fs = appconfig.ConfigFields
+	} else {
+		shownOptions := 4
+		fs.ByName["Planet.Name"].Options = append(appconfig.ConfigFields.ByName["Planet.Name"].Options[:shownOptions], fmt.Sprintf("%v... [Use --help-all to show all %v options]", appconfig.ConfigFields.ByName["Planet.Name"].Options[shownOptions], len(appconfig.ConfigFields.ByName["Planet.Name"].Options)))
 	}
 
 	formatFieldName := func(field string) string {

--- a/cmd/filediver-gui/game_data_manager.go
+++ b/cmd/filediver-gui/game_data_manager.go
@@ -41,6 +41,9 @@ type GameData struct {
 
 	FilterExpr    *app.FilterExprProgram
 	FilterExprErr error
+
+	AssetOverridesDirty bool
+	ColorGrading        stingray.FileID
 }
 
 func NewGameData(a *app.App) *GameData {
@@ -125,6 +128,15 @@ func (gd *GameData) UpdateSearchQuery(query string, allowedTypes map[stingray.Ha
 	slices.SortFunc(gd.SortedSearchResultFileIDs, func(a, b stingray.FileID) int {
 		return strings.Compare(gd.KnownFileNames[a], gd.KnownFileNames[b])
 	})
+}
+
+func (gd *GameData) UpdateAssetOverrides(planetName string, city bool) {
+	planet := gd.App.UpdateAssetOverrides(planetName, city)
+	gd.ColorGrading = stingray.FileID{}
+	if planet != nil {
+		gd.ColorGrading = stingray.NewFileID(planet.PaletteGroupLowland.AssetGrading, stingray.Sum("entity"))
+	}
+	gd.AssetOverridesDirty = true
 }
 
 func (gd *GameData) GoExport(extractCtx context.Context, files []stingray.FileID, outDir string, cfg appconfig.Config, runner *exec.Runner, archiveIDs []stingray.Hash, printer app.Printer, allowMp4Export bool) *GameDataExport {

--- a/cmd/filediver-gui/game_data_manager.go
+++ b/cmd/filediver-gui/game_data_manager.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
-	"regexp"
 	"runtime"
 	"slices"
 	"strings"
@@ -23,8 +21,6 @@ import (
 	"github.com/xypwn/filediver/hashes"
 	"github.com/xypwn/filediver/stingray"
 	stingray_strings "github.com/xypwn/filediver/stingray/strings"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 type GameDataExport struct {
@@ -142,29 +138,6 @@ func (gd *GameData) UpdateAssetOverrides(planetName string, city bool) {
 		gd.ColorGrading = stingray.NewFileID(planet.PaletteGroupLowland.AssetGrading, stingray.Sum("entity"))
 	}
 	gd.AssetOverridesDirty = true
-}
-
-func (gd *GameData) EnsurePlanetNameOptions() {
-	// Hack to add dynamic options for planet names so that we don't have to regenerate the code
-	// every game update
-	if appconfig.ConfigFields.ByName["Planet.Name"].Options != nil {
-		return
-	}
-	hasAlpha := regexp.MustCompile("[a-z]").MatchString
-	titleCaser := cases.Title(language.English)
-	romanNumeral := regexp.MustCompile("(?i)\\WM{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})\\W?")
-	planetNames := slices.Collect(maps.Keys(gd.Planets))
-	slices.Sort(planetNames)
-	for i := 0; i < len(planetNames); {
-		if !hasAlpha(planetNames[i]) || (i+1 < len(planetNames) && planetNames[i] == planetNames[i+1]) {
-			planetNames = append(planetNames[:i], planetNames[i+1:]...)
-			continue
-		}
-		planetNames[i] = titleCaser.String(planetNames[i])
-		planetNames[i] = romanNumeral.ReplaceAllStringFunc(planetNames[i], strings.ToUpper)
-		i++
-	}
-	appconfig.ConfigFields.ByName["Planet.Name"].Options = append([]string{" "}, planetNames...)
 }
 
 func (gd *GameData) GoExport(extractCtx context.Context, files []stingray.FileID, outDir string, cfg appconfig.Config, runner *exec.Runner, archiveIDs []stingray.Hash, printer app.Printer, allowMp4Export bool) *GameDataExport {
@@ -309,7 +282,6 @@ func (gd *GameDataLoad) loadGameData(ctx context.Context, gameDir string) {
 	res := NewGameData(a)
 	gd.Lock()
 	gd.Result = res
-	gd.Result.EnsurePlanetNameOptions()
 	gd.Done = true
 	gd.Unlock()
 }

--- a/cmd/filediver-gui/game_data_manager.go
+++ b/cmd/filediver-gui/game_data_manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"regexp"
 	"runtime"
 	"slices"
 	"strings"
@@ -21,6 +23,8 @@ import (
 	"github.com/xypwn/filediver/hashes"
 	"github.com/xypwn/filediver/stingray"
 	stingray_strings "github.com/xypwn/filediver/stingray/strings"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type GameDataExport struct {
@@ -131,12 +135,36 @@ func (gd *GameData) UpdateSearchQuery(query string, allowedTypes map[stingray.Ha
 }
 
 func (gd *GameData) UpdateAssetOverrides(planetName string, city bool) {
-	planet := gd.App.UpdateAssetOverrides(planetName, city)
+	gd.App.UpdateAssetOverrides(planetName, city)
+	planet := gd.GetPlanet(planetName, city)
 	gd.ColorGrading = stingray.FileID{}
 	if planet != nil {
 		gd.ColorGrading = stingray.NewFileID(planet.PaletteGroupLowland.AssetGrading, stingray.Sum("entity"))
 	}
 	gd.AssetOverridesDirty = true
+}
+
+func (gd *GameData) EnsurePlanetNameOptions() {
+	// Hack to add dynamic options for planet names so that we don't have to regenerate the code
+	// every game update
+	if appconfig.ConfigFields.ByName["Planet.Name"].Options != nil {
+		return
+	}
+	hasAlpha := regexp.MustCompile("[a-z]").MatchString
+	titleCaser := cases.Title(language.English)
+	romanNumeral := regexp.MustCompile("(?i)\\WM{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})\\W?")
+	planetNames := slices.Collect(maps.Keys(gd.Planets))
+	slices.Sort(planetNames)
+	for i := 0; i < len(planetNames); {
+		if !hasAlpha(planetNames[i]) || (i+1 < len(planetNames) && planetNames[i] == planetNames[i+1]) {
+			planetNames = append(planetNames[:i], planetNames[i+1:]...)
+			continue
+		}
+		planetNames[i] = titleCaser.String(planetNames[i])
+		planetNames[i] = romanNumeral.ReplaceAllStringFunc(planetNames[i], strings.ToUpper)
+		i++
+	}
+	appconfig.ConfigFields.ByName["Planet.Name"].Options = append([]string{" "}, planetNames...)
 }
 
 func (gd *GameData) GoExport(extractCtx context.Context, files []stingray.FileID, outDir string, cfg appconfig.Config, runner *exec.Runner, archiveIDs []stingray.Hash, printer app.Printer, allowMp4Export bool) *GameDataExport {
@@ -281,6 +309,7 @@ func (gd *GameDataLoad) loadGameData(ctx context.Context, gameDir string) {
 	res := NewGameData(a)
 	gd.Lock()
 	gd.Result = res
+	gd.Result.EnsurePlanetNameOptions()
 	gd.Done = true
 	gd.Unlock()
 }

--- a/cmd/filediver-gui/main.go
+++ b/cmd/filediver-gui/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"slices"
@@ -40,6 +41,8 @@ import (
 	"github.com/xypwn/filediver/exec"
 	"github.com/xypwn/filediver/stingray"
 	"golang.design/x/clipboard"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 //go:embed LICENSE
@@ -350,7 +353,7 @@ func (a *guiApp) onInitWindow(state *imgui_wrapper.State) error {
 		state.FrameRate = a.preferences.TargetFPS
 	}
 
-	// Laod extractor config
+	// Load extractor config
 	{
 		if err := a.extractorConfig.Load(a.extractorConfigPath); err != nil {
 			return fmt.Errorf("loading extractor config: %w", err)
@@ -378,6 +381,11 @@ func (a *guiApp) onPreDraw(state *imgui_wrapper.State) error {
 			a.gameData.Hashes,
 			a.gameData.ThinHashes,
 			func(id stingray.FileID, typ stingray.DataType) (data []byte, exists bool, err error) {
+				if a.gameData.AssetOverrides != nil && *a.gameData.AssetOverrides != nil {
+					if val, contains := (*a.gameData.AssetOverrides)[id]; contains {
+						id = val
+					}
+				}
 				data, err = a.gameData.DataDir.Read(id, typ)
 				if err == stingray.ErrFileNotExist || err == stingray.ErrFileDataTypeNotExist {
 					return nil, false, nil
@@ -893,11 +901,12 @@ func (a *guiApp) drawBrowserWindow() {
 				imgui.EndTable()
 			}
 
-			if a.preview != nil && newActiveFileID != a.preview.ActiveID() {
+			if a.preview != nil && (newActiveFileID != a.preview.ActiveID() || a.gameData.AssetOverridesDirty) {
 				if !noPushToHistory {
 					a.historyPush(a.preview.ActiveID(), newActiveFileID)
 				}
-				a.preview.LoadFile(a.ctx, newActiveFileID, a.preferences.PreviewVideoVerticalResolution)
+				a.preview.LoadFile(a.ctx, newActiveFileID, a.preferences.PreviewVideoVerticalResolution, a.gameData.ColorGrading, a.gameData.EntityVarMapping)
+				a.gameData.AssetOverridesDirty = false
 			}
 
 			imutils.Textf("Showing %v/%v files (%v selected for export)", len(a.gameData.SortedSearchResultFileIDs), len(a.gameData.DataDir.Files), len(a.filesSelectedForExport))
@@ -1119,12 +1128,36 @@ func (a *guiApp) drawExportWindow() {
 }
 
 func (a *guiApp) drawExtractorConfigWindow() {
+	// Hack to add dynamic options for planet names so that we don't have to regenerate the code
+	// every game update
+	//
+	// (There's probably a better place for this to go)
+	if a.gameData != nil && appconfig.ConfigFields.ByName["Planet.Name"].Options == nil {
+		hasAlpha := regexp.MustCompile("[a-z]").MatchString
+		titleCaser := cases.Title(language.English)
+		romanNumeral := regexp.MustCompile("(?i)\\WM{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})\\W?")
+		planetNames := slices.Collect(maps.Keys(a.gameData.Planets))
+		slices.Sort(planetNames)
+		for i := 0; i < len(planetNames); {
+			if !hasAlpha(planetNames[i]) || (i+1 < len(planetNames) && planetNames[i] == planetNames[i+1]) {
+				planetNames = append(planetNames[:i], planetNames[i+1:]...)
+				continue
+			}
+			planetNames[i] = titleCaser.String(planetNames[i])
+			planetNames[i] = romanNumeral.ReplaceAllStringFunc(planetNames[i], strings.ToUpper)
+			i++
+		}
+		appconfig.ConfigFields.ByName["Planet.Name"].Options = append([]string{" "}, planetNames...)
+	}
 	if imgui.Begin(fnt.I.SettingsApplications + " Extractor config") {
 		prevExtrCfg := a.extractorConfig
 		if widgets.ConfigEditor(&a.extractorConfig, &a.extractorConfigShowAdvanced, &a.extractorConfigSearchQuery) {
 			if a.extractorConfig.Gamedir != prevExtrCfg.Gamedir {
 				a.gameData = nil
 				a.gameDataLoad.GoLoadGameData(a.ctx, a.extractorConfig.Gamedir)
+			}
+			if a.extractorConfig.Planet.Name != prevExtrCfg.Planet.Name || a.extractorConfig.Planet.City != prevExtrCfg.Planet.City {
+				a.gameData.UpdateAssetOverrides(a.extractorConfig.Planet.Name, a.extractorConfig.Planet.City)
 			}
 			if a.extractorConfig != prevExtrCfg {
 				if err := a.extractorConfig.Save(a.extractorConfigPath); err != nil {

--- a/cmd/filediver-gui/main.go
+++ b/cmd/filediver-gui/main.go
@@ -380,20 +380,22 @@ func (a *guiApp) onPreDraw(state *imgui_wrapper.State) error {
 			a.otoCtx, a.audioSampleRate,
 			a.gameData.Hashes,
 			a.gameData.ThinHashes,
-			func(id stingray.FileID, typ stingray.DataType) (data []byte, exists bool, err error) {
-				if a.gameData.AssetOverrides != nil && *a.gameData.AssetOverrides != nil {
-					if val, contains := (*a.gameData.AssetOverrides)[id]; contains {
-						id = val
+			func(allowOverride bool) func(id stingray.FileID, typ stingray.DataType) (data []byte, exists bool, err error) {
+				return func(id stingray.FileID, typ stingray.DataType) (data []byte, exists bool, err error) {
+					if allowOverride && a.gameData.AssetOverrides != nil && *a.gameData.AssetOverrides != nil {
+						if val, contains := (*a.gameData.AssetOverrides)[id]; contains {
+							id = val
+						}
 					}
+					data, err = a.gameData.DataDir.Read(id, typ)
+					if err == stingray.ErrFileNotExist || err == stingray.ErrFileDataTypeNotExist {
+						return nil, false, nil
+					}
+					if err != nil {
+						return nil, false, err
+					}
+					return data, true, nil
 				}
-				data, err = a.gameData.DataDir.Read(id, typ)
-				if err == stingray.ErrFileNotExist || err == stingray.ErrFileDataTypeNotExist {
-					return nil, false, nil
-				}
-				if err != nil {
-					return nil, false, err
-				}
-				return data, true, nil
 			},
 			a.runner,
 		)
@@ -683,6 +685,7 @@ func (a *guiApp) drawBrowserWindow() {
 								}),
 							},
 						}
+						a.gameData.UpdateAssetOverrides(a.extractorConfig.Planet.Name, a.extractorConfig.Planet.City)
 					}
 				} else {
 					imutils.TextError(a.gameDataLoad.Err)

--- a/cmd/filediver-gui/main.go
+++ b/cmd/filediver-gui/main.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"runtime/debug"
 	"slices"
@@ -41,8 +40,6 @@ import (
 	"github.com/xypwn/filediver/exec"
 	"github.com/xypwn/filediver/stingray"
 	"golang.design/x/clipboard"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 //go:embed LICENSE
@@ -398,6 +395,11 @@ func (a *guiApp) onPreDraw(state *imgui_wrapper.State) error {
 				}
 			},
 			a.runner,
+			previews.ExtractorPlanetParameters{
+				Name:                 &a.extractorConfig.Planet.Name,
+				UseCity:              &a.extractorConfig.Planet.City,
+				UpdateAssetOverrides: a.gameData.UpdateAssetOverrides,
+			},
 		)
 		if err != nil {
 			return fmt.Errorf("creating preview: %w", err)
@@ -1131,27 +1133,6 @@ func (a *guiApp) drawExportWindow() {
 }
 
 func (a *guiApp) drawExtractorConfigWindow() {
-	// Hack to add dynamic options for planet names so that we don't have to regenerate the code
-	// every game update
-	//
-	// (There's probably a better place for this to go)
-	if a.gameData != nil && appconfig.ConfigFields.ByName["Planet.Name"].Options == nil {
-		hasAlpha := regexp.MustCompile("[a-z]").MatchString
-		titleCaser := cases.Title(language.English)
-		romanNumeral := regexp.MustCompile("(?i)\\WM{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})\\W?")
-		planetNames := slices.Collect(maps.Keys(a.gameData.Planets))
-		slices.Sort(planetNames)
-		for i := 0; i < len(planetNames); {
-			if !hasAlpha(planetNames[i]) || (i+1 < len(planetNames) && planetNames[i] == planetNames[i+1]) {
-				planetNames = append(planetNames[:i], planetNames[i+1:]...)
-				continue
-			}
-			planetNames[i] = titleCaser.String(planetNames[i])
-			planetNames[i] = romanNumeral.ReplaceAllStringFunc(planetNames[i], strings.ToUpper)
-			i++
-		}
-		appconfig.ConfigFields.ByName["Planet.Name"].Options = append([]string{" "}, planetNames...)
-	}
 	if imgui.Begin(fnt.I.SettingsApplications + " Extractor config") {
 		prevExtrCfg := a.extractorConfig
 		if widgets.ConfigEditor(&a.extractorConfig, &a.extractorConfigShowAdvanced, &a.extractorConfigSearchQuery) {

--- a/cmd/filediver-gui/widgets/previews/auto_preview.go
+++ b/cmd/filediver-gui/widgets/previews/auto_preview.go
@@ -15,6 +15,8 @@ import (
 	"github.com/xypwn/filediver/dds"
 	"github.com/xypwn/filediver/exec"
 	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/stingray/entity"
+	"github.com/xypwn/filediver/stingray/shading_environment"
 	stingray_strings "github.com/xypwn/filediver/stingray/strings"
 	"github.com/xypwn/filediver/stingray/unit/material"
 	"github.com/xypwn/filediver/stingray/unit/texture"
@@ -102,7 +104,7 @@ func (pv *AutoPreview) NeedCJKFont() bool {
 	return pv.previews.strings.NeedCJKFont()
 }
 
-func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, maxVideoVerticalResolution int) {
+func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, maxVideoVerticalResolution int, colorGrading stingray.FileID, entityVarMapping shading_environment.ShadingEnvironmentEntityToShaderMapping) {
 	if fileID == (stingray.FileID{}) {
 		pv.activeID.Name.Value = 0
 		pv.activeID.Type.Value = 0
@@ -157,12 +159,18 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 			pv.err = err
 			return
 		}
+		var entityInfo *entity.Entity
+		entityData, exists, err := pv.getResource(colorGrading, stingray.DataMain)
+		if err == nil && exists {
+			entityInfo, err = entity.LoadEntity(bytes.NewReader(entityData), entityVarMapping)
+		}
 		if err := pv.previews.speedtree.LoadSpeedtree(
 			fileID.Name,
 			data[stingray.DataMain],
 			data[stingray.DataGPU],
 			pv.getResource,
 			pv.thinhashes,
+			entityInfo,
 		); err != nil {
 			pv.err = fmt.Errorf("loading speedtree: %w", err)
 			return

--- a/cmd/filediver-gui/widgets/previews/auto_preview.go
+++ b/cmd/filediver-gui/widgets/previews/auto_preview.go
@@ -58,7 +58,13 @@ type AutoPreview struct {
 	err error
 }
 
-func NewAutoPreview(otoCtx *oto.Context, audioSampleRate int, hashes map[stingray.Hash]string, thinhashes map[stingray.ThinHash]string, getResourceGenerator GetResourceGeneratorFunc, runner *exec.Runner) (*AutoPreview, error) {
+type ExtractorPlanetParameters struct {
+	Name                 *string
+	UseCity              *bool
+	UpdateAssetOverrides func(string, bool)
+}
+
+func NewAutoPreview(otoCtx *oto.Context, audioSampleRate int, hashes map[stingray.Hash]string, thinhashes map[stingray.ThinHash]string, getResourceGenerator GetResourceGeneratorFunc, runner *exec.Runner, planetParams ExtractorPlanetParameters) (*AutoPreview, error) {
 	var err error
 	pv := &AutoPreview{
 		hashes:               hashes,
@@ -69,7 +75,7 @@ func NewAutoPreview(otoCtx *oto.Context, audioSampleRate int, hashes map[stingra
 	if err != nil {
 		return nil, err
 	}
-	pv.previews.speedtree, err = NewSpeedtreePreview()
+	pv.previews.speedtree, err = NewSpeedtreePreview(planetParams)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/filediver-gui/widgets/previews/auto_preview.go
+++ b/cmd/filediver-gui/widgets/previews/auto_preview.go
@@ -51,19 +51,19 @@ type AutoPreview struct {
 		xaml      *XamlPreview
 	}
 
-	hashes      map[stingray.Hash]string
-	thinhashes  map[stingray.ThinHash]string
-	getResource GetResourceFunc
+	hashes               map[stingray.Hash]string
+	thinhashes           map[stingray.ThinHash]string
+	getResourceGenerator GetResourceGeneratorFunc
 
 	err error
 }
 
-func NewAutoPreview(otoCtx *oto.Context, audioSampleRate int, hashes map[stingray.Hash]string, thinhashes map[stingray.ThinHash]string, getResource GetResourceFunc, runner *exec.Runner) (*AutoPreview, error) {
+func NewAutoPreview(otoCtx *oto.Context, audioSampleRate int, hashes map[stingray.Hash]string, thinhashes map[stingray.ThinHash]string, getResourceGenerator GetResourceGeneratorFunc, runner *exec.Runner) (*AutoPreview, error) {
 	var err error
 	pv := &AutoPreview{
-		hashes:      hashes,
-		thinhashes:  thinhashes,
-		getResource: getResource,
+		hashes:               hashes,
+		thinhashes:           thinhashes,
+		getResourceGenerator: getResourceGenerator,
 	}
 	pv.previews.unit, err = NewUnitPreview()
 	if err != nil {
@@ -125,7 +125,7 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 			if data[typ] != nil {
 				panic("programmer error: duplicate data type")
 			}
-			b, exists, err := pv.getResource(fileID, typ)
+			b, exists, err := pv.getResourceGenerator(false)(fileID, typ)
 			if err != nil {
 				return fmt.Errorf("reading file: %w", err)
 			}
@@ -147,7 +147,7 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 			fileID.Name,
 			data[stingray.DataMain],
 			data[stingray.DataGPU],
-			pv.getResource,
+			pv.getResourceGenerator(true),
 			pv.thinhashes,
 		); err != nil {
 			pv.err = fmt.Errorf("loading unit: %w", err)
@@ -160,7 +160,7 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 			return
 		}
 		var entityInfo *entity.Entity
-		entityData, exists, err := pv.getResource(colorGrading, stingray.DataMain)
+		entityData, exists, err := pv.getResourceGenerator(false)(colorGrading, stingray.DataMain)
 		if err == nil && exists {
 			entityInfo, err = entity.LoadEntity(bytes.NewReader(entityData), entityVarMapping)
 		}
@@ -168,7 +168,7 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 			fileID.Name,
 			data[stingray.DataMain],
 			data[stingray.DataGPU],
-			pv.getResource,
+			pv.getResourceGenerator(true),
 			pv.thinhashes,
 			entityInfo,
 		); err != nil {
@@ -205,7 +205,7 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 					Name: stingray.Sum(path.Join(dir, fmt.Sprint(id))),
 					Type: stingray.Sum("wwise_stream"),
 				}
-				return pv.getResource(fileID, stingray.DataStream)
+				return pv.getResourceGenerator(false)(fileID, stingray.DataStream)
 			},
 		)
 		if err != nil {
@@ -292,7 +292,7 @@ func (pv *AutoPreview) LoadFile(ctx context.Context, fileID stingray.FileID, max
 			return
 		}
 
-		err = pv.previews.material.LoadMaterial(data, pv.getResource, pv.hashes, pv.thinhashes)
+		err = pv.previews.material.LoadMaterial(data, pv.getResourceGenerator(false), pv.hashes, pv.thinhashes)
 		if err != nil {
 			pv.err = fmt.Errorf("loading material: %w", err)
 			return

--- a/cmd/filediver-gui/widgets/previews/preview_common.go
+++ b/cmd/filediver-gui/widgets/previews/preview_common.go
@@ -5,3 +5,4 @@ import (
 )
 
 type GetResourceFunc func(id stingray.FileID, typ stingray.DataType) (data []byte, exists bool, err error)
+type GetResourceGeneratorFunc func(allowOverrides bool) func(id stingray.FileID, typ stingray.DataType) (data []byte, exists bool, err error)

--- a/cmd/filediver-gui/widgets/previews/shaders/speedtree.frag
+++ b/cmd/filediver-gui/widgets/previews/shaders/speedtree.frag
@@ -55,9 +55,12 @@ vec3 graded(vec3 color) {
     int leafGroup = group(vec3(grading_group_id, grading_group_id_secondworld, grading_group_id_thirdworld));
     int trunkGroup = group(vec3(grading_group_id_trunk));
 
-    mat4 leafGrading = gradingMatrix(leafGroup);
+    mat4 leafGrading = mat4(1.0);
+    if (leafGroup >= 0) {
+        leafGrading = gradingMatrix(leafGroup);
+    }
     mat4 trunkGrading = mat4(1.0);
-    if (grading_group_id_trunk > 0.0) {
+    if (trunkGroup >= 0) {
         trunkGrading = gradingMatrix(trunkGroup);
     }
     vec3 leafGraded = gradeColor(color, leafGrading);

--- a/cmd/filediver-gui/widgets/previews/shaders/speedtree.frag
+++ b/cmd/filediver-gui/widgets/previews/shaders/speedtree.frag
@@ -48,9 +48,8 @@ vec3 gradeColor(vec3 color, mat4 matrix) {
 }
 
 vec3 graded(vec3 color) {
-    //color = pow(color, vec3(1.0/2.2));
-    float worldval = (abs(fract(world*12) - 0.5) * 2 - 1) * world_grading_color_value_variation + 1;
     float tex2_alpha = texture(tex2, fragUV).w;
+    float worldval = (abs(fract(world*12) - 0.5) * 2 - 1) * world_grading_color_value_variation + 1;
     float subsurface = 1.0 - min(clamp(clamp(floor(tex2_alpha * 63.75) / 63.0, 0.0, 1.0) * ss_intensity_mult, 0.0, 1.0) * 100, 1.0);
     int leafGroup = group(vec3(grading_group_id, grading_group_id_secondworld, grading_group_id_thirdworld));
     int trunkGroup = group(vec3(grading_group_id_trunk));
@@ -67,7 +66,6 @@ vec3 graded(vec3 color) {
     vec3 trunkGraded = gradeColor(color, trunkGrading);
 
     return (-leafGraded * worldval + trunkGraded) * subsurface + (leafGraded * worldval);
-    return pow((-leafGraded * worldval + trunkGraded) * subsurface + (leafGraded * worldval), vec3(2.2));
 }
 
 void main() {

--- a/cmd/filediver-gui/widgets/previews/shaders/speedtree.frag
+++ b/cmd/filediver-gui/widgets/previews/shaders/speedtree.frag
@@ -10,13 +10,61 @@ in vec3 fragTangentFragmentPosition;
 in mat3 dbg_fragTBN;
 in mat3 dbg_fragITBN;
 
+uniform float grading_group_id;
+uniform float grading_group_id_secondworld;
+uniform float grading_group_id_thirdworld;
+uniform float grading_group_id_trunk;
+uniform float world_grading_color_value_variation;
+uniform float ss_intensity_mult;
+uniform float world;
+
 uniform sampler2D texAlbedo;
 uniform sampler2D texNormal;
+uniform sampler2D tex2;
+uniform samplerBuffer texAssetGrading;
 uniform float opacityThreshold;
 
 // Reconstructs the Z value if Z was truncated from XYZ.
 float reconstructNormalZ(vec2 xy) {
     return sqrt(1.0 - xy.x*xy.x - xy.y*xy.y);
+}
+
+int group(vec3 ids) {
+    float selectId = world < 0.667 ? ids.y : ids.z;
+    selectId = world < 0.333 ? ids.x : selectId;
+    return int(floor(selectId+0.5)) * 4 - 4;
+}
+
+mat4 gradingMatrix(int groupId) {
+    vec4 row0 = texelFetch(texAssetGrading, groupId);
+    vec4 row1 = texelFetch(texAssetGrading, groupId + 1);
+    vec4 row2 = texelFetch(texAssetGrading, groupId + 2);
+    vec4 row3 = texelFetch(texAssetGrading, groupId + 3);
+    return mat4(row0, row1, row2, row3);
+}
+
+vec3 gradeColor(vec3 color, mat4 matrix) {
+    return (color.y * matrix[1].xyz) + (color.x * matrix[0].xyz) + (color.z * matrix[2].xyz) + matrix[3].xyz;
+}
+
+vec3 graded(vec3 color) {
+    //color = pow(color, vec3(1.0/2.2));
+    float worldval = (abs(fract(world*12) - 0.5) * 2 - 1) * world_grading_color_value_variation + 1;
+    float tex2_alpha = texture(tex2, fragUV).w;
+    float subsurface = 1.0 - min(clamp(clamp(floor(tex2_alpha * 63.75) / 63.0, 0.0, 1.0) * ss_intensity_mult, 0.0, 1.0) * 100, 1.0);
+    int leafGroup = group(vec3(grading_group_id, grading_group_id_secondworld, grading_group_id_thirdworld));
+    int trunkGroup = group(vec3(grading_group_id_trunk));
+
+    mat4 leafGrading = gradingMatrix(leafGroup);
+    mat4 trunkGrading = mat4(1.0);
+    if (grading_group_id_trunk > 0.0) {
+        trunkGrading = gradingMatrix(trunkGroup);
+    }
+    vec3 leafGraded = gradeColor(color, leafGrading);
+    vec3 trunkGraded = gradeColor(color, trunkGrading);
+
+    return (-leafGraded * worldval + trunkGraded) * subsurface + (leafGraded * worldval);
+    return pow((-leafGraded * worldval + trunkGraded) * subsurface + (leafGraded * worldval), vec3(2.2));
 }
 
 void main() {
@@ -25,7 +73,7 @@ void main() {
         discard;
     }
 
-    vec3 albedo = albedoOpacity.xyz;
+    vec3 albedo = graded(albedoOpacity.xyz);
     vec3 normal = texture(texNormal, fragUV).xyz;
 
     normal = normal * 2.0 - 1.0; // in tangent space

--- a/cmd/filediver-gui/widgets/previews/speedtree_preview.go
+++ b/cmd/filediver-gui/widgets/previews/speedtree_preview.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AllenDang/cimgui-go/imgui"
 	"github.com/go-gl/gl/v4.3-core/gl"
 	"github.com/go-gl/mathgl/mgl32"
+	"github.com/xypwn/filediver/app/appconfig"
 	fnt "github.com/xypwn/filediver/cmd/filediver-gui/fonts"
 	"github.com/xypwn/filediver/cmd/filediver-gui/glutils"
 	"github.com/xypwn/filediver/cmd/filediver-gui/imutils"
@@ -176,12 +177,33 @@ type SpeedtreePreviewState struct {
 	visualizeTangentBitangent int32 // 1 or 0
 	autoZoomEnabled           bool
 	doAutoZoomNextFrame       bool
+
+	extractorPlanet      *string
+	extractorUseCity     *bool
+	updateAssetOverrides func(string, bool)
+	planetComboWidth     float32
 }
 
-func NewSpeedtreePreview() (*SpeedtreePreviewState, error) {
+func NewSpeedtreePreview(planetParams ExtractorPlanetParameters) (*SpeedtreePreviewState, error) {
 	var err error
 
 	pv := &SpeedtreePreviewState{}
+	if planetParams.Name == nil || planetParams.UseCity == nil || planetParams.UpdateAssetOverrides == nil {
+		return nil, fmt.Errorf("programming error - extractor planet parameters not correctly set")
+	}
+	pv.extractorPlanet = planetParams.Name
+	pv.extractorUseCity = planetParams.UseCity
+	pv.updateAssetOverrides = planetParams.UpdateAssetOverrides
+
+	currentStyle := imgui.CurrentStyle()
+	maxPlanetWidth := float32(0.0)
+	comboBoxArrowWidth := imgui.TextLineHeightWithSpacing()
+	for _, option := range appconfig.ConfigFields.ByName["Planet.Name"].Options {
+		if newWidth := imgui.CalcTextSize(option).X + currentStyle.FramePadding().X*2.0 + comboBoxArrowWidth; newWidth > maxPlanetWidth {
+			maxPlanetWidth = newWidth
+		}
+	}
+	pv.planetComboWidth = maxPlanetWidth
 
 	pv.fb, err = widgets.NewGLView()
 	if err != nil {
@@ -1023,6 +1045,10 @@ func SpeedtreePreview(name string, pv *SpeedtreePreviewState) {
 		},
 	)
 
+	// TODO: refactor this + unit controls/settings into a separate window
+	// in the same vein as the material settings display - should help with
+	// resizing and allowing the controls to take up as much or as little
+	// spaces as they need
 	if imgui.Button(fnt.I.Home) {
 		pv.viewRotation = mgl32.Vec2{}
 		pv.doAutoZoomNextFrame = true
@@ -1082,6 +1108,15 @@ func SpeedtreePreview(name string, pv *SpeedtreePreviewState) {
 	imgui.SameLine()
 	if imgui.Checkbox(fnt.I.AllOut+" Auto-zoom", &pv.autoZoomEnabled) && pv.autoZoomEnabled {
 		pv.doAutoZoomNextFrame = true
+	}
+	imgui.SameLine()
+	imgui.SetNextItemWidth(pv.planetComboWidth)
+	if imutils.ComboChoice(fnt.I.Planet+" Planet", pv.extractorPlanet, appconfig.ConfigFields.ByName["Planet.Name"].Options) {
+		pv.updateAssetOverrides(*pv.extractorPlanet, *pv.extractorUseCity)
+	}
+	imgui.SameLine()
+	if imgui.Checkbox(fnt.I.LocationCity+" City", pv.extractorUseCity) {
+		pv.updateAssetOverrides(*pv.extractorPlanet, *pv.extractorUseCity)
 	}
 	imgui.SameLine()
 	// UDim selection

--- a/cmd/filediver-gui/widgets/previews/speedtree_preview.go
+++ b/cmd/filediver-gui/widgets/previews/speedtree_preview.go
@@ -594,7 +594,7 @@ func (pv *SpeedtreePreviewState) LoadSpeedtree(fileID stingray.Hash, mainData, g
 				err = uploadStingrayTexture(pv.object.materials[materialIndex].tex2, tex2Hash)
 			}
 			if err != nil {
-				return fmt.Errorf("load tex2 %v.texture: %w", normalHash, err)
+				return fmt.Errorf("load tex2 %v.texture: %w", tex2Hash, err)
 			}
 
 			assetGradingLut := extr_entity.CreateIdentityColorGradingLut()
@@ -808,6 +808,7 @@ func SpeedtreePreview(name string, pv *SpeedtreePreviewState) {
 					gl.Uniform1f(pv.treeUniforms["grading_group_id_trunk"], pv.object.materials[idx].gradingGroupIdTrunk)
 					gl.Uniform1f(pv.treeUniforms["world_grading_color_value_variation"], pv.object.materials[idx].worldGradingCVV)
 					gl.Uniform1f(pv.treeUniforms["ss_intensity_mult"], pv.object.materials[idx].subsurfaceIntensity)
+					gl.Uniform1f(pv.treeUniforms["world"], 0.0)
 					gl.ActiveTexture(gl.TEXTURE0)
 					gl.BindTexture(gl.TEXTURE_2D, pv.object.materials[idx].texAlbedoOpacity)
 					gl.ActiveTexture(gl.TEXTURE1)
@@ -815,7 +816,7 @@ func SpeedtreePreview(name string, pv *SpeedtreePreviewState) {
 					gl.ActiveTexture(gl.TEXTURE2)
 					gl.BindTexture(gl.TEXTURE_2D, pv.object.lutFibonacci)
 					gl.ActiveTexture(gl.TEXTURE3)
-					gl.BindTexture(gl.TEXTURE_BUFFER, pv.object.materials[idx].tex2)
+					gl.BindTexture(gl.TEXTURE_2D, pv.object.materials[idx].tex2)
 					gl.ActiveTexture(gl.TEXTURE4)
 					gl.BindTexture(gl.TEXTURE_BUFFER, pv.object.materials[idx].texAssetGrading)
 				}

--- a/cmd/filediver-gui/widgets/previews/speedtree_preview.go
+++ b/cmd/filediver-gui/widgets/previews/speedtree_preview.go
@@ -3,6 +3,7 @@ package previews
 import (
 	"bytes"
 	"cmp"
+	"encoding/binary"
 	"fmt"
 	"image"
 	"io"
@@ -18,7 +19,9 @@ import (
 	"github.com/xypwn/filediver/cmd/filediver-gui/widgets"
 	datalib "github.com/xypwn/filediver/datalibrary"
 	"github.com/xypwn/filediver/dds"
+	extr_entity "github.com/xypwn/filediver/extractor/entity"
 	"github.com/xypwn/filediver/stingray"
+	"github.com/xypwn/filediver/stingray/entity"
 	"github.com/xypwn/filediver/stingray/speedtree"
 	"github.com/xypwn/filediver/stingray/unit"
 	"github.com/xypwn/filediver/stingray/unit/material"
@@ -28,10 +31,18 @@ import (
 type speedtreeMaterial struct {
 	texAlbedoOpacity uint32
 	texNormalRG      uint32
+	tex2             uint32
+	texAssetGrading  uint32
 
-	indexOffset      int32
-	indexCount       int32
-	opacityThreshold float32
+	indexOffset         int32
+	indexCount          int32
+	opacityThreshold    float32
+	gradingGroupId      float32
+	gradingGroupId2     float32
+	gradingGroupId3     float32
+	gradingGroupIdTrunk float32
+	worldGradingCVV     float32
+	subsurfaceIntensity float32
 }
 
 type speedtreePreviewObject struct {
@@ -39,6 +50,7 @@ type speedtreePreviewObject struct {
 	ibo          uint32 // index buffer object
 	vbo          uint32 // vertex buffer object
 	lutFibonacci uint32
+	lutGrading   uint32
 
 	numVertices int32
 	numIndices  int32
@@ -55,6 +67,7 @@ func (obj *speedtreePreviewObject) genObjects() {
 	gl.GenVertexArrays(1, &obj.vao)
 	gl.GenBuffers(1, &obj.vbo)
 	gl.GenBuffers(1, &obj.ibo)
+	gl.GenBuffers(1, &obj.lutGrading)
 	gl.GenTextures(1, &obj.lutFibonacci)
 
 	gl.BindVertexArray(obj.vao)
@@ -71,6 +84,8 @@ func (obj *speedtreePreviewObject) genMaterials(count int) {
 	for idx := range obj.materials {
 		gl.GenTextures(1, &obj.materials[idx].texAlbedoOpacity)
 		gl.GenTextures(1, &obj.materials[idx].texNormalRG)
+		gl.GenTextures(1, &obj.materials[idx].tex2)
+		gl.GenTextures(1, &obj.materials[idx].texAssetGrading)
 	}
 }
 
@@ -96,10 +111,13 @@ func (obj speedtreePreviewObject) deleteObjects() {
 	gl.DeleteVertexArrays(1, &obj.vao)
 	gl.DeleteBuffers(1, &obj.vbo)
 	gl.DeleteBuffers(1, &obj.ibo)
+	gl.DeleteBuffers(1, &obj.lutGrading)
 	gl.DeleteTextures(1, &obj.lutFibonacci)
 	for _, material := range obj.materials {
 		gl.DeleteTextures(1, &material.texAlbedoOpacity)
 		gl.DeleteTextures(1, &material.texNormalRG)
+		gl.DeleteTextures(1, &material.tex2)
+		gl.DeleteTextures(1, &material.texAssetGrading)
 	}
 }
 
@@ -178,7 +196,7 @@ func NewSpeedtreePreview() (*SpeedtreePreviewState, error) {
 	if err != nil {
 		return nil, err
 	}
-	pv.treeUniforms.generate(pv.treeProgram, "mvp", "model", "normalMat", "viewPosition", "texAlbedo", "texNormal", "opacityThreshold", "fibonacci_normal_lut")
+	pv.treeUniforms.generate(pv.treeProgram, "mvp", "model", "normalMat", "viewPosition", "texAlbedo", "texNormal", "tex2", "texAssetGrading", "opacityThreshold", "fibonacci_normal_lut", "grading_group_id", "grading_group_id_secondworld", "grading_group_id_thirdworld", "grading_group_id_trunk", "world_grading_color_value_variation", "ss_intensity_mult", "world")
 
 	pv.objectWireframeProgram, err = glutils.CreateProgramFromSources(unitPreviewShaderCode,
 		"shaders/speedtree_wireframe.vert",
@@ -225,6 +243,8 @@ func NewSpeedtreePreview() (*SpeedtreePreviewState, error) {
 	gl.Uniform1i(pv.treeUniforms["texAlbedo"], 0)
 	gl.Uniform1i(pv.treeUniforms["texNormal"], 1)
 	gl.Uniform1i(pv.treeUniforms["fibonacci_normal_lut"], 2)
+	gl.Uniform1i(pv.treeUniforms["tex2"], 3)
+	gl.Uniform1i(pv.treeUniforms["texAssetGrading"], 4)
 	gl.UseProgram(0)
 
 	gl.UseProgram(pv.objectNormalVisProgram)
@@ -277,7 +297,7 @@ func (pv *SpeedtreePreviewState) loadMesh(meshInfos []unit.MeshInfo, meshLayouts
 	return mesh, nil
 }
 
-func (pv *SpeedtreePreviewState) LoadSpeedtree(fileID stingray.Hash, mainData, gpuData []byte, getResource GetResourceFunc, thinhashes map[stingray.ThinHash]string) error {
+func (pv *SpeedtreePreviewState) LoadSpeedtree(fileID stingray.Hash, mainData, gpuData []byte, getResource GetResourceFunc, thinhashes map[stingray.ThinHash]string, entityInfo *entity.Entity) error {
 	info, err := speedtree.LoadSpeedTree(bytes.NewReader(mainData))
 	if err != nil {
 		return err
@@ -470,6 +490,16 @@ func (pv *SpeedtreePreviewState) LoadSpeedtree(fileID stingray.Hash, mainData, g
 		return nil
 	}
 
+	uploadGradingTexture := func(textureID uint32, data []byte) error {
+		gl.BindBuffer(gl.TEXTURE_BUFFER, pv.object.lutGrading)
+		gl.BufferData(gl.TEXTURE_BUFFER, len(data), gl.Ptr(data), gl.STATIC_DRAW)
+		gl.BindBuffer(gl.TEXTURE_BUFFER, 0)
+		gl.BindTexture(gl.TEXTURE_BUFFER, textureID)
+		gl.TexBuffer(gl.TEXTURE_BUFFER, gl.RGBA16F, pv.object.lutGrading)
+		gl.BindTexture(gl.TEXTURE_BUFFER, 0)
+		return nil
+	}
+
 	// Load materials
 	{
 		pv.object.genMaterials(int(lod0.MeshCount))
@@ -501,10 +531,41 @@ func (pv *SpeedtreePreviewState) LoadSpeedtree(fileID stingray.Hash, mainData, g
 			if !ok {
 				opacityThreshold = []float32{0.5}
 			}
+			gradingGroupId, ok := mat.Settings[stingray.Sum("grading_group_id").Thin()]
+			if !ok {
+				gradingGroupId = []float32{0.0}
+			}
+			gradingGroupId2, ok := mat.Settings[stingray.Sum("grading_group_id_secondworld").Thin()]
+			if !ok {
+				gradingGroupId2 = gradingGroupId
+			}
+			gradingGroupId3, ok := mat.Settings[stingray.Sum("grading_group_id_thirdworld").Thin()]
+			if !ok {
+				gradingGroupId3 = gradingGroupId
+			}
+			gradingGroupIdTrunk, ok := mat.Settings[stingray.Sum("grading_group_id_trunk").Thin()]
+			if !ok {
+				gradingGroupIdTrunk = []float32{0.5}
+			}
+			worldGradingCVV, ok := mat.Settings[stingray.Sum("world_grading_color_value_variation").Thin()]
+			if !ok {
+				worldGradingCVV = []float32{0}
+			}
+			subsurfaceIntensity, ok := mat.Settings[stingray.Sum("ss_intensity_mult").Thin()]
+			if !ok {
+				subsurfaceIntensity = []float32{1.0}
+			}
 			pv.object.materials[materialIndex].opacityThreshold = opacityThreshold[0]
+			pv.object.materials[materialIndex].gradingGroupId = gradingGroupId[0]
+			pv.object.materials[materialIndex].gradingGroupId2 = gradingGroupId2[0]
+			pv.object.materials[materialIndex].gradingGroupId3 = gradingGroupId3[0]
+			pv.object.materials[materialIndex].gradingGroupIdTrunk = gradingGroupIdTrunk[0]
+			pv.object.materials[materialIndex].worldGradingCVV = worldGradingCVV[0]
+			pv.object.materials[materialIndex].subsurfaceIntensity = subsurfaceIntensity[0]
 
 			setupTexture(pv.object.materials[materialIndex].texAlbedoOpacity)
 			setupTexture(pv.object.materials[materialIndex].texNormalRG)
+			setupTexture(pv.object.materials[materialIndex].tex2)
 
 			albedoOpacityHash := getTextureSlotPath(mat, stingray.Sum("tex0").Thin())
 			if albedoOpacityHash.Value == 0x0 {
@@ -524,6 +585,30 @@ func (pv *SpeedtreePreviewState) LoadSpeedtree(fileID stingray.Hash, mainData, g
 			}
 			if err != nil {
 				return fmt.Errorf("load tex1 %v.texture: %w", normalHash, err)
+			}
+
+			tex2Hash := getTextureSlotPath(mat, stingray.Sum("tex2").Thin())
+			if tex2Hash.Value == 0x0 {
+				err = uploadMissingTexture(pv.object.materials[materialIndex].tex2, []byte{255, 255, 255, 255})
+			} else {
+				err = uploadStingrayTexture(pv.object.materials[materialIndex].tex2, tex2Hash)
+			}
+			if err != nil {
+				return fmt.Errorf("load tex2 %v.texture: %w", normalHash, err)
+			}
+
+			assetGradingLut := extr_entity.CreateIdentityColorGradingLut()
+			if entityInfo != nil {
+				entityAssetGradingLut, err := extr_entity.CreateColorGradingLut(entityInfo)
+				if err == nil {
+					assetGradingLut = entityAssetGradingLut
+				}
+			}
+			var buf bytes.Buffer
+			binary.Write(&buf, binary.LittleEndian, assetGradingLut)
+			err = uploadGradingTexture(pv.object.materials[materialIndex].texAssetGrading, buf.Bytes())
+			if err != nil {
+				return fmt.Errorf("upload grading texture: %w", err)
 			}
 
 			pv.object.materials[materialIndex].indexCount = int32(meshDef.IndexCount)
@@ -717,12 +802,22 @@ func SpeedtreePreview(name string, pv *SpeedtreePreviewState) {
 			for idx := range pv.object.materials {
 				if !pv.showWireframe {
 					gl.Uniform1f(pv.treeUniforms["opacityThreshold"], pv.object.materials[idx].opacityThreshold)
+					gl.Uniform1f(pv.treeUniforms["grading_group_id"], pv.object.materials[idx].gradingGroupId)
+					gl.Uniform1f(pv.treeUniforms["grading_group_id_secondworld"], pv.object.materials[idx].gradingGroupId2)
+					gl.Uniform1f(pv.treeUniforms["grading_group_id_thirdworld"], pv.object.materials[idx].gradingGroupId3)
+					gl.Uniform1f(pv.treeUniforms["grading_group_id_trunk"], pv.object.materials[idx].gradingGroupIdTrunk)
+					gl.Uniform1f(pv.treeUniforms["world_grading_color_value_variation"], pv.object.materials[idx].worldGradingCVV)
+					gl.Uniform1f(pv.treeUniforms["ss_intensity_mult"], pv.object.materials[idx].subsurfaceIntensity)
 					gl.ActiveTexture(gl.TEXTURE0)
 					gl.BindTexture(gl.TEXTURE_2D, pv.object.materials[idx].texAlbedoOpacity)
 					gl.ActiveTexture(gl.TEXTURE1)
 					gl.BindTexture(gl.TEXTURE_2D, pv.object.materials[idx].texNormalRG)
 					gl.ActiveTexture(gl.TEXTURE2)
 					gl.BindTexture(gl.TEXTURE_2D, pv.object.lutFibonacci)
+					gl.ActiveTexture(gl.TEXTURE3)
+					gl.BindTexture(gl.TEXTURE_BUFFER, pv.object.materials[idx].tex2)
+					gl.ActiveTexture(gl.TEXTURE4)
+					gl.BindTexture(gl.TEXTURE_BUFFER, pv.object.materials[idx].texAssetGrading)
 				}
 				gl.DrawElements(gl.TRIANGLES, pv.object.materials[idx].indexCount, pv.object.indexType, gl.Ptr(uintptr(pv.object.indexStride*pv.object.materials[idx].indexOffset)))
 			}

--- a/cmd/tools/fdtools-common/fdtools.go
+++ b/cmd/tools/fdtools-common/fdtools.go
@@ -12,29 +12,42 @@ import (
 	stingray_strings "github.com/xypwn/filediver/stingray/strings"
 )
 
-func createPrinter() app.Printer {
-	return app.NewConsolePrinter(
+// Initializes the tool with a printer and app with game files and
+// adds a --gamedir (-a) argument, then executes the arg parser.
+//
+// This function is very impure: It will invoke the printer and may
+// exit the entire program. This is because it is solely intended
+// for standalone tools at the moment.
+//
+// Simply shuts down the program on failure (calls os.Exit(1) via prt.Fatalf).
+// Calls os.Exit(0) if --help (-h) is passed.
+func Init(argp *argparse.Parser) (prt app.Printer, a *app.App) {
+	prt = app.NewConsolePrinter(
 		supportscolor.Stderr().SupportsColor,
 		os.Stderr,
 		os.Stderr,
 	)
-}
 
-func addLanguages(argp *argparse.Parser) *string {
+	optGameDir := argp.String("g", "gamedir", nil)
 	langs := make([]any, len(stingray_strings.LanguageFriendlyNames))
 	for i := range langs {
 		langs[i] = stingray_strings.LanguageFriendlyNames[i]
 	}
-	return argp.String("l", "language", &argparse.Option{
+	optLanguage := argp.String("l", "language", &argparse.Option{
 		Default: "English (US)",
 		Choices: langs,
 		Help:    "Language to use when exporting names and descriptions",
 	})
-}
+	if err := argp.Parse(nil); err != nil {
+		if err == argparse.BreakAfterHelpError {
+			os.Exit(0)
+		} else {
+			prt.Fatalf("%v", err)
+		}
+	}
 
-func loadApp(prt app.Printer, optGameDir, optStringsLanguage *string) (*app.App, error) {
 	var gameDir string
-	if optGameDir == nil || *optGameDir == "" {
+	if *optGameDir == "" {
 		var err error
 		gameDir, err = app.DetectGameDir()
 		if err == nil {
@@ -50,58 +63,9 @@ func loadApp(prt app.Printer, optGameDir, optStringsLanguage *string) (*app.App,
 	ctx := context.Background() // no need to exit cleanly since we're only reading
 	knownHashes := app.ParseHashes(hashes.Hashes)
 	knownThinHashes := app.ParseHashes(hashes.ThinHashes)
-	return app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray_strings.LanguageFriendlyNameToHash[*optStringsLanguage], func(curr, total int) {
+	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray_strings.LanguageFriendlyNameToHash[*optLanguage], func(curr, total int) {
 		prt.Statusf("Reading metadata %.0f%%", float64(curr)/float64(total)*100)
 	})
-}
-
-// Initializes the tool with a printer and app with game files and
-// adds --gamedir (-g) and --language (-l) arguments, then executes the arg parser.
-//
-// This function is very impure: It will invoke the printer and may
-// exit the entire program. This is because it is solely intended
-// for standalone tools at the moment.
-//
-// Simply shuts down the program on failure (calls os.Exit(1) via prt.Fatalf).
-// Calls os.Exit(0) if --help (-h) is passed.
-func Init(argp *argparse.Parser) (prt app.Printer, a *app.App) {
-	prt = createPrinter()
-
-	optGameDir := argp.String("g", "gamedir", nil)
-	optStringsLanguage := addLanguages(argp)
-	if err := argp.Parse(nil); err != nil {
-		if err == argparse.BreakAfterHelpError {
-			os.Exit(0)
-		} else {
-			prt.Fatalf("%v", err)
-		}
-	}
-
-	a, err := loadApp(prt, optGameDir, optStringsLanguage)
-	if err != nil {
-		prt.Fatalf("Error opening game dir: %v", err)
-	}
-	prt.NoStatus()
-	return
-}
-
-func InitWithLanguage(argp *argparse.Parser, language string) (prt app.Printer, a *app.App) {
-	prt = createPrinter()
-
-	optGameDir := argp.String("g", "gamedir", nil)
-	if err := argp.Parse(nil); err != nil {
-		if err == argparse.BreakAfterHelpError {
-			os.Exit(0)
-		} else {
-			prt.Fatalf("%v", err)
-		}
-	}
-
-	if language == "" {
-		language = "English (US)"
-	}
-
-	a, err := loadApp(prt, optGameDir, &language)
 	if err != nil {
 		prt.Fatalf("Error opening game dir: %v", err)
 	}

--- a/cmd/tools/fdtools-common/fdtools.go
+++ b/cmd/tools/fdtools-common/fdtools.go
@@ -9,36 +9,32 @@ import (
 	"github.com/jwalton/go-supportscolor"
 	"github.com/xypwn/filediver/app"
 	"github.com/xypwn/filediver/hashes"
-	"github.com/xypwn/filediver/stingray"
+	stingray_strings "github.com/xypwn/filediver/stingray/strings"
 )
 
-// Initializes the tool with a printer and app with game files and
-// adds a --gamedir (-a) argument, then executes the arg parser.
-//
-// This function is very impure: It will invoke the printer and may
-// exit the entire program. This is because it is solely intended
-// for standalone tools at the moment.
-//
-// Simply shuts down the program on failure (calls os.Exit(1) via prt.Fatalf).
-// Calls os.Exit(0) if --help (-h) is passed.
-func Init(argp *argparse.Parser) (prt app.Printer, a *app.App) {
-	prt = app.NewConsolePrinter(
+func createPrinter() app.Printer {
+	return app.NewConsolePrinter(
 		supportscolor.Stderr().SupportsColor,
 		os.Stderr,
 		os.Stderr,
 	)
+}
 
-	optGameDir := argp.String("g", "gamedir", nil)
-	if err := argp.Parse(nil); err != nil {
-		if err == argparse.BreakAfterHelpError {
-			os.Exit(0)
-		} else {
-			prt.Fatalf("%v", err)
-		}
+func addLanguages(argp *argparse.Parser) *string {
+	langs := make([]any, len(stingray_strings.LanguageFriendlyNames))
+	for i := range langs {
+		langs[i] = stingray_strings.LanguageFriendlyNames[i]
 	}
+	return argp.String("l", "language", &argparse.Option{
+		Default: "English (US)",
+		Choices: langs,
+		Help:    "Language to use when exporting names and descriptions",
+	})
+}
 
+func loadApp(prt app.Printer, optGameDir, optStringsLanguage *string) (*app.App, error) {
 	var gameDir string
-	if *optGameDir == "" {
+	if optGameDir == nil || *optGameDir == "" {
 		var err error
 		gameDir, err = app.DetectGameDir()
 		if err == nil {
@@ -54,9 +50,58 @@ func Init(argp *argparse.Parser) (prt app.Printer, a *app.App) {
 	ctx := context.Background() // no need to exit cleanly since we're only reading
 	knownHashes := app.ParseHashes(hashes.Hashes)
 	knownThinHashes := app.ParseHashes(hashes.ThinHashes)
-	a, err := app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray.ThinHash{}, func(curr, total int) {
+	return app.OpenGameDir(ctx, gameDir, knownHashes, knownThinHashes, stingray_strings.LanguageFriendlyNameToHash[*optStringsLanguage], func(curr, total int) {
 		prt.Statusf("Reading metadata %.0f%%", float64(curr)/float64(total)*100)
 	})
+}
+
+// Initializes the tool with a printer and app with game files and
+// adds --gamedir (-g) and --language (-l) arguments, then executes the arg parser.
+//
+// This function is very impure: It will invoke the printer and may
+// exit the entire program. This is because it is solely intended
+// for standalone tools at the moment.
+//
+// Simply shuts down the program on failure (calls os.Exit(1) via prt.Fatalf).
+// Calls os.Exit(0) if --help (-h) is passed.
+func Init(argp *argparse.Parser) (prt app.Printer, a *app.App) {
+	prt = createPrinter()
+
+	optGameDir := argp.String("g", "gamedir", nil)
+	optStringsLanguage := addLanguages(argp)
+	if err := argp.Parse(nil); err != nil {
+		if err == argparse.BreakAfterHelpError {
+			os.Exit(0)
+		} else {
+			prt.Fatalf("%v", err)
+		}
+	}
+
+	a, err := loadApp(prt, optGameDir, optStringsLanguage)
+	if err != nil {
+		prt.Fatalf("Error opening game dir: %v", err)
+	}
+	prt.NoStatus()
+	return
+}
+
+func InitWithLanguage(argp *argparse.Parser, language string) (prt app.Printer, a *app.App) {
+	prt = createPrinter()
+
+	optGameDir := argp.String("g", "gamedir", nil)
+	if err := argp.Parse(nil); err != nil {
+		if err == argparse.BreakAfterHelpError {
+			os.Exit(0)
+		} else {
+			prt.Fatalf("%v", err)
+		}
+	}
+
+	if language == "" {
+		language = "English (US)"
+	}
+
+	a, err := loadApp(prt, optGameDir, &language)
 	if err != nil {
 		prt.Fatalf("Error opening game dir: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ type Tag struct {
 	Help string
 	// String enum options, or nil
 	Options []string
+	// Truncate options after 5 values
+	Truncate bool
 	// Default values in order of priority (highest first)
 	// (type-checked), or nil
 	Default []any
@@ -238,6 +240,11 @@ func parseTag(
 				return nil, fmt.Errorf("options is only available for fields of type string")
 			}
 			res.Options = strings.Split(value, ",")
+		case "truncate":
+			if res.Truncate != false {
+				return nil, fmt.Errorf("duplicate %v field", strconv.Quote(key))
+			}
+			res.Truncate = true
 		case "default":
 			if res.Default != nil {
 				return nil, fmt.Errorf("duplicate %v field", strconv.Quote(key))
@@ -575,6 +582,7 @@ func (f Field) DefaultValue() any {
 func (fs *FieldSet) FieldFormatHint(
 	field string,
 	formatFieldName func(field string) string,
+	showAdvancedHelp bool,
 ) string {
 	f := fs.ByName[field]
 
@@ -584,7 +592,13 @@ func (fs *FieldSet) FieldFormatHint(
 
 	var items []string
 	if len(f.Options) > 0 {
-		items = append(items, fmt.Sprintf("options: %v", strings.Join(f.Options, "|")))
+		length := len(f.Options)
+		showExtra := ""
+		if length > 5 && f.Truncate && !showAdvancedHelp {
+			showExtra = fmt.Sprintf("... [Use --help-all to show all %v options]", length)
+			length = 5
+		}
+		items = append(items, fmt.Sprintf("options: %v%v", strings.Join(f.Options[:length], "|"), showExtra))
 	}
 	if f.RangeMin != nil || f.RangeMax != nil {
 		items = append(items, fmt.Sprintf("range: %v...%v", f.RangeMin, f.RangeMax))

--- a/datalibrary/enum/regionflag.go
+++ b/datalibrary/enum/regionflag.go
@@ -6,7 +6,7 @@ const (
 	RegionFlag_None RegionFlag = iota
 	RegionFlag_Value_1_Len_17
 	RegionFlag_Value_2_Len_17
-	RegionFlag_Value_3_Len_15
+	RegionFlag_City
 	RegionFlag_Value_4_Len_15
 	RegionFlag_Value_5_Len_24
 	RegionFlag_Count

--- a/datalibrary/enum/regionflag_string.go
+++ b/datalibrary/enum/regionflag_string.go
@@ -11,15 +11,15 @@ func _() {
 	_ = x[RegionFlag_None-0]
 	_ = x[RegionFlag_Value_1_Len_17-1]
 	_ = x[RegionFlag_Value_2_Len_17-2]
-	_ = x[RegionFlag_Value_3_Len_15-3]
+	_ = x[RegionFlag_City-3]
 	_ = x[RegionFlag_Value_4_Len_15-4]
 	_ = x[RegionFlag_Value_5_Len_24-5]
 	_ = x[RegionFlag_Count-6]
 }
 
-const _RegionFlag_name = "RegionFlag_NoneRegionFlag_Value_1_Len_17RegionFlag_Value_2_Len_17RegionFlag_Value_3_Len_15RegionFlag_Value_4_Len_15RegionFlag_Value_5_Len_24RegionFlag_Count"
+const _RegionFlag_name = "RegionFlag_NoneRegionFlag_Value_1_Len_17RegionFlag_Value_2_Len_17RegionFlag_CityRegionFlag_Value_4_Len_15RegionFlag_Value_5_Len_24RegionFlag_Count"
 
-var _RegionFlag_index = [...]uint8{0, 15, 40, 65, 90, 115, 140, 156}
+var _RegionFlag_index = [...]uint8{0, 15, 40, 65, 80, 105, 130, 146}
 
 func (i RegionFlag) String() string {
 	idx := int(i) - 0

--- a/datalibrary/planet_override_settings.go
+++ b/datalibrary/planet_override_settings.go
@@ -35,6 +35,20 @@ type PlanetOverrideSettings struct {
 	Overrides []PlanetOverrides
 }
 
+type PlanetOverridesMap map[stingray.ThinHash]map[stingray.FileID]stingray.FileID
+
+func (p PlanetOverrideSettings) ToMap() PlanetOverridesMap {
+	result := make(PlanetOverridesMap)
+	for _, override := range p.Overrides {
+		resources := make(map[stingray.FileID]stingray.FileID)
+		for _, resourceOverride := range override.Resources {
+			resources[stingray.NewFileID(resourceOverride.Replace, resourceOverride.Type)] = stingray.NewFileID(resourceOverride.ReplaceWith, resourceOverride.Type)
+		}
+		result[override.ID] = resources
+	}
+	return result
+}
+
 func LoadPlanetOverrideSettings(lookupHash HashLookup, lookupThinHash ThinHashLookup, lookupStrings StringsLookup) ([]PlanetOverrideSettings, error) {
 	r := bytes.NewReader(planetOverrideSettings)
 

--- a/extractor/context.go
+++ b/extractor/context.go
@@ -52,6 +52,8 @@ type Context struct {
 	files []string
 
 	materialOverrides map[stingray.ThinHash]stingray.Hash
+	assetOverrides    map[stingray.FileID]stingray.FileID
+	colorGrading      stingray.Hash
 }
 
 // NewContext creates a new [Context].
@@ -99,6 +101,8 @@ func NewContext(
 
 		fileID:     fileID,
 		rootFileID: fileID,
+
+		colorGrading: stingray.Hash{Value: 0x0},
 	}
 	return c, func() []string { return c.files }
 }
@@ -130,6 +134,8 @@ func (c *Context) WithFileID(newFileID stingray.FileID) *Context {
 		statusf:            c.statusf,
 
 		materialOverrides: c.materialOverrides,
+		assetOverrides:    c.assetOverrides,
+		colorGrading:      c.colorGrading,
 
 		fileID:     newFileID,
 		rootFileID: c.rootFileID,
@@ -160,6 +166,72 @@ func (c *Context) WithMaterialOverrides(newOverrides map[stingray.ThinHash]sting
 		statusf:            c.statusf,
 
 		materialOverrides: newOverrides,
+		assetOverrides:    c.assetOverrides,
+		colorGrading:      c.colorGrading,
+
+		fileID:     c.fileID,
+		rootFileID: c.rootFileID,
+
+		files: c.files,
+	}
+}
+
+// Returns a copy of the context with different asset overrides
+func (c *Context) WithAssetOverrides(newOverrides map[stingray.FileID]stingray.FileID) *Context {
+	return &Context{
+		ctx:                c.ctx,
+		hashes:             c.hashes,
+		thinHashes:         c.thinHashes,
+		armorSets:          c.armorSets,
+		skinOverrideGroups: c.skinOverrideGroups,
+		weaponPaintSchemes: c.weaponPaintSchemes,
+		attachmentSlots:    c.attachmentSlots,
+		entityVarMapping:   c.entityVarMapping,
+		gameBuildInfo:      c.gameBuildInfo,
+		languageMap:        c.languageMap,
+		dataDir:            c.dataDir,
+		runner:             c.runner,
+		config:             c.config,
+		outPath:            c.outPath,
+		selectedArchives:   c.selectedArchives,
+		warnf:              c.warnf,
+		statusf:            c.statusf,
+
+		materialOverrides: c.materialOverrides,
+		assetOverrides:    newOverrides,
+		colorGrading:      c.colorGrading,
+
+		fileID:     c.fileID,
+		rootFileID: c.rootFileID,
+
+		files: c.files,
+	}
+}
+
+// Returns a copy of the context with different asset overrides
+func (c *Context) WithColorGrading(colorGrading stingray.Hash) *Context {
+	return &Context{
+		ctx:                c.ctx,
+		hashes:             c.hashes,
+		thinHashes:         c.thinHashes,
+		armorSets:          c.armorSets,
+		skinOverrideGroups: c.skinOverrideGroups,
+		weaponPaintSchemes: c.weaponPaintSchemes,
+		attachmentSlots:    c.attachmentSlots,
+		entityVarMapping:   c.entityVarMapping,
+		gameBuildInfo:      c.gameBuildInfo,
+		languageMap:        c.languageMap,
+		dataDir:            c.dataDir,
+		runner:             c.runner,
+		config:             c.config,
+		outPath:            c.outPath,
+		selectedArchives:   c.selectedArchives,
+		warnf:              c.warnf,
+		statusf:            c.statusf,
+
+		materialOverrides: c.materialOverrides,
+		assetOverrides:    c.assetOverrides,
+		colorGrading:      colorGrading,
 
 		fileID:     c.fileID,
 		rootFileID: c.rootFileID,
@@ -177,6 +249,22 @@ func (c *Context) OverrideMaterial(slot stingray.ThinHash, original stingray.Has
 		return override
 	}
 	return original
+}
+
+// Transparently return the override for an asset if it exists, otherwise return the original
+func (c *Context) OverrideAsset(asset stingray.FileID) stingray.FileID {
+	if c.assetOverrides == nil {
+		return asset
+	}
+	if override, contains := c.assetOverrides[asset]; contains {
+		return override
+	}
+	return asset
+}
+
+// Get the current context's color grading entity hash
+func (c *Context) ColorGrading() stingray.Hash {
+	return c.colorGrading
 }
 
 // FileID gets the ID of the current file to be extracted.

--- a/extractor/entity/extractor.go
+++ b/extractor/entity/extractor.go
@@ -315,7 +315,7 @@ func getF32(data any) (float32, error) {
 	return s, nil
 }
 
-func createColorGradingLut(entityInfo *entity.Entity) ([]Vec4F16, error) {
+func CreateColorGradingLut(entityInfo *entity.Entity) ([]Vec4F16, error) {
 	var colorGradingLut []mgl32.Vec4
 	for _, info := range entityInfo.Infos {
 		if colorGradingLut != nil {
@@ -402,6 +402,18 @@ func createColorGradingLut(entityInfo *entity.Entity) ([]Vec4F16, error) {
 	return convertToFloat16(colorGradingLut), nil
 }
 
+func CreateIdentityColorGradingLut() []Vec4F16 {
+	row0, row1, row2, row3 := mgl32.Ident4().Rows()
+	colorGradingLut := convertToFloat16([]mgl32.Vec4{row0, row1, row2, row3}) // 4
+	colorGradingLut = append(colorGradingLut, colorGradingLut...)             // 8
+	colorGradingLut = append(colorGradingLut, colorGradingLut...)             // 16
+	colorGradingLut = append(colorGradingLut, colorGradingLut...)             // 32
+	colorGradingLut = append(colorGradingLut, colorGradingLut...)             // 64
+	colorGradingLut = append(colorGradingLut, colorGradingLut[:36]...)        // 100
+
+	return colorGradingLut
+}
+
 func writeDDS(w io.Writer, colorGradingLut []Vec4F16) error {
 	if err := binary.Write(w, binary.LittleEndian, []byte("DDS ")); err != nil {
 		return err
@@ -451,7 +463,7 @@ func writeDDS(w io.Writer, colorGradingLut []Vec4F16) error {
 }
 
 func WriteDDSColorGradingLut(w io.Writer, entityInfo *entity.Entity) error {
-	colorGradingLut, err := createColorGradingLut(entityInfo)
+	colorGradingLut, err := CreateColorGradingLut(entityInfo)
 	if err != nil {
 		return err
 	}
@@ -460,13 +472,5 @@ func WriteDDSColorGradingLut(w io.Writer, entityInfo *entity.Entity) error {
 }
 
 func WriteDDSIdentityColorGradingLut(w io.Writer) error {
-	row0, row1, row2, row3 := mgl32.Ident4().Rows()
-	colorGradingLut := convertToFloat16([]mgl32.Vec4{row0, row1, row2, row3}) // 4
-	colorGradingLut = append(colorGradingLut, colorGradingLut...)             // 8
-	colorGradingLut = append(colorGradingLut, colorGradingLut...)             // 16
-	colorGradingLut = append(colorGradingLut, colorGradingLut...)             // 32
-	colorGradingLut = append(colorGradingLut, colorGradingLut...)             // 64
-	colorGradingLut = append(colorGradingLut, colorGradingLut[:36]...)        // 100
-
-	return writeDDS(w, colorGradingLut)
+	return writeDDS(w, CreateIdentityColorGradingLut())
 }

--- a/extractor/geometry_group/extractor.go
+++ b/extractor/geometry_group/extractor.go
@@ -38,7 +38,7 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 	doc := extractor.GetDocument(ctx, gltfDoc)
 
 	for unitHash, meshInfo := range geoGroup.MeshInfos {
-		unitId := stingray.NewFileID(unitHash, stingray.Sum("unit"))
+		unitId := ctx.OverrideAsset(stingray.NewFileID(unitHash, stingray.Sum("unit")))
 		f, err := ctx.Open(unitId, stingray.DataMain)
 		if err == stingray.ErrFileNotExist {
 			return fmt.Errorf("%v.unit does not exist", unitId.Name.String())

--- a/extractor/level/extractor.go
+++ b/extractor/level/extractor.go
@@ -424,7 +424,7 @@ func ConvertOpts(ctx *extractor.Context, gltfDoc *gltf.Document) error {
 			percentComplete := 100 * float32(idx+1) / totalObjectCount
 			ctx.Statusf("%.2f%% - %v.prefab", percentComplete, ctx.LookupHash(prefab.Path))
 		}
-		prefabId := stingray.NewFileID(prefab.Path, stingray.Sum("prefab"))
+		prefabId := ctx.OverrideAsset(stingray.NewFileID(prefab.Path, stingray.Sum("prefab")))
 		node, err := extr_prefab.AddPrefab(ctx.WithFileID(prefabId), doc, imgOpts)
 		if err != nil {
 			return err
@@ -476,7 +476,7 @@ func ConvertOpts(ctx *extractor.Context, gltfDoc *gltf.Document) error {
 		for _, entry := range levelData.Metadata[idx] {
 			metadata[entry.Key(ctx.LookupThinHash)] = entry.Value()
 		}
-		unitId := stingray.NewFileID(unit.Path(), stingray.Sum("unit"))
+		unitId := ctx.OverrideAsset(stingray.NewFileID(unit.Path(), stingray.Sum("unit")))
 		err := extr_prefab.AddOrDuplicateModel(ctx.WithFileID(unitId), doc, imgOpts, &unit, levelIdx, materialOverrides, metadata)
 		if err != nil {
 			return err
@@ -491,7 +491,7 @@ func ConvertOpts(ctx *extractor.Context, gltfDoc *gltf.Document) error {
 			percentComplete := 100 * float32(idx+1+len(levelData.Prefabs)+len(levelData.Units)) / totalObjectCount
 			ctx.Statusf("%.2f%% - %v.speedtree", percentComplete, ctx.LookupHash(speedtree.Path()))
 		}
-		speedtreeId := stingray.NewFileID(speedtree.Path(), stingray.Sum("speedtree"))
+		speedtreeId := ctx.OverrideAsset(stingray.NewFileID(speedtree.Path(), stingray.Sum("speedtree")))
 		for _, transform := range speedtree.Transforms {
 			speedtreeTransformed := SpeedtreeTransformed{
 				Speedtree: speedtree,

--- a/extractor/material/extractor.go
+++ b/extractor/material/extractor.go
@@ -460,19 +460,21 @@ func WriteDDS(ctx *extractor.Context, doc *gltf.Document, ddsR io.ReadSeeker, po
 // Adds a texture to doc. Returns new texture ID if err != nil.
 // postProcess optionally applies image post-processing.
 func writeTexture(ctx *extractor.Context, doc *gltf.Document, id stingray.Hash, postProcess func(image.Image) (image.Image, error), imgOpts *ImageOptions, suffix string) (uint32, error) {
+	textureId := ctx.OverrideAsset(stingray.NewFileID(id, stingray.Sum("texture")))
 	// Check if we've already added this texture
 	for j, texture := range doc.Textures {
-		if doc.Images[*texture.Source].Name == (id.String() + suffix) {
+		if doc.Images[*texture.Source].Name == (textureId.Name.String() + suffix) {
 			return uint32(j), nil
 		}
 	}
 
-	ddsData, err := extr_texture.ExtractDDSData(ctx, stingray.NewFileID(id, stingray.Sum("texture")))
+	ddsData, err := extr_texture.ExtractDDSData(ctx, textureId)
 	if err != nil {
 		return 0, err
 	}
 	ddsR := bytes.NewReader(ddsData)
-	return WriteDDS(ctx.WithFileID(stingray.NewFileID(id, stingray.Sum("texture"))), doc, ddsR, postProcess, imgOpts, suffix)
+
+	return WriteDDS(ctx.WithFileID(textureId), doc, ddsR, postProcess, imgOpts, suffix)
 }
 
 func combineIlluminateOcclusionMetallicRoughness(narImg, dataImg image.Image) error {

--- a/extractor/prefab/extractor.go
+++ b/extractor/prefab/extractor.go
@@ -326,7 +326,7 @@ func AddPrefab(ctx *extractor.Context, doc *gltf.Document, imgOpts *extr_materia
 			percentComplete := 100 * float32(idx+1) / float32(len(prefabData.Units)+len(prefabData.NestedPrefabs))
 			ctx.Statusf("%.2f%% - %v.unit", percentComplete, ctx.LookupHash(object.Path()))
 		}
-		unitId := stingray.NewFileID(object.Path(), stingray.Sum("unit"))
+		unitId := ctx.OverrideAsset(stingray.NewFileID(object.Path(), stingray.Sum("unit")))
 		err := AddOrDuplicateModel(ctx.WithFileID(unitId), doc, imgOpts, &object, prefabRoot, nil, nil)
 		if err != nil {
 			return 0, err
@@ -341,7 +341,7 @@ func AddPrefab(ctx *extractor.Context, doc *gltf.Document, imgOpts *extr_materia
 			percentComplete := 100 * float32(idx+1+len(prefabData.Units)) / float32(len(prefabData.Units)+len(prefabData.NestedPrefabs))
 			ctx.Statusf("%.2f%% - %v.prefab", percentComplete, ctx.LookupHash(nested.Path))
 		}
-		nestedId := stingray.NewFileID(nested.Path, stingray.Sum("prefab"))
+		nestedId := ctx.OverrideAsset(stingray.NewFileID(nested.Path, stingray.Sum("prefab")))
 		root, err := AddPrefab(ctx.WithFileID(nestedId), doc, imgOpts)
 		if err != nil {
 			return 0, fmt.Errorf("extracting prefab %v: %v", ctx.LookupHash(nested.Path), err)

--- a/extractor/speedtree/extractor.go
+++ b/extractor/speedtree/extractor.go
@@ -207,16 +207,11 @@ func AddPrefabMetadata(ctx *extractor.Context, doc *gltf.Document, root *uint32,
 	doc.Extras = extras
 }
 
-func WriteColorGradingLut(ctx *extractor.Context, colorGradingEntity string, colorGradingDDS *bytes.Buffer) error {
-	entityHash, err := stingray.ParseOrSum(colorGradingEntity)
-	if err != nil {
-		extr_entity.WriteDDSIdentityColorGradingLut(colorGradingDDS)
-		return err
-	}
-	entityID := stingray.NewFileID(entityHash, stingray.Sum("entity"))
+func WriteColorGradingLut(ctx *extractor.Context, colorGradingDDS *bytes.Buffer) error {
+	entityID := stingray.NewFileID(ctx.ColorGrading(), stingray.Sum("entity"))
 	if !ctx.Exists(entityID, stingray.DataMain) {
 		extr_entity.WriteDDSIdentityColorGradingLut(colorGradingDDS)
-		return fmt.Errorf("entity %v does not exist", colorGradingEntity)
+		return fmt.Errorf("entity %v does not exist", entityID.Name.String())
 	}
 	entityData, err := ctx.Open(entityID, stingray.DataMain)
 	if err != nil {
@@ -260,10 +255,12 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 	}
 
 	var colorGradingDDS bytes.Buffer
-	if cfg.SpeedTree.ColorGrading == "" {
+	if ctx.ColorGrading().Value == 0x0 {
+		ctx.Warnf("Writing identity color grading lut")
 		err = extr_entity.WriteDDSIdentityColorGradingLut(&colorGradingDDS)
 	} else {
-		err = WriteColorGradingLut(ctx, cfg.SpeedTree.ColorGrading, &colorGradingDDS)
+		ctx.Warnf("Writing color grading lut")
+		err = WriteColorGradingLut(ctx, &colorGradingDDS)
 	}
 	if err != nil {
 		ctx.Warnf("Writing color grading lut: %v", err)
@@ -271,9 +268,10 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 
 	materialMap := make(map[uint64]uint32)
 	for _, mat := range treeInfo.StingrayMaterials {
-		matR, err := ctx.Open(stingray.NewFileID(mat.Path, stingray.Sum("material")), stingray.DataMain)
+		materialId := ctx.OverrideAsset(stingray.NewFileID(mat.Path, stingray.Sum("material")))
+		matR, err := ctx.Open(materialId, stingray.DataMain)
 		if err == stingray.ErrFileNotExist {
-			return fmt.Errorf("referenced material resource %v doesn't exist", mat.Path)
+			return fmt.Errorf("referenced material resource %v doesn't exist", materialId.Name)
 		}
 		if err != nil {
 			return err
@@ -282,14 +280,13 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 		if err != nil {
 			return err
 		}
-		matPath := ctx.LookupHash(mat.Path)
+		matPath := ctx.LookupHash(materialId.Name)
 		if strings.Contains(matPath, "/") {
 			split := strings.Split(matPath, "/")
 			matPath = strings.Join(split[len(split)-2:], "/")
 		}
-		colorGradingName, err := stingray.ParseOrSum(cfg.SpeedTree.ColorGrading)
-		if err != nil {
-			ctx.Warnf("Invalid speed tree color grading entity name")
+		colorGradingName := ctx.ColorGrading()
+		if ctx.ColorGrading().Value == 0x0 {
 			colorGradingName = stingray.Sum("identity")
 		}
 		colorGradingId := stingray.NewFileID(colorGradingName, stingray.Sum("texture"))

--- a/extractor/speedtree/extractor.go
+++ b/extractor/speedtree/extractor.go
@@ -256,10 +256,8 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 
 	var colorGradingDDS bytes.Buffer
 	if ctx.ColorGrading().Value == 0x0 {
-		ctx.Warnf("Writing identity color grading lut")
 		err = extr_entity.WriteDDSIdentityColorGradingLut(&colorGradingDDS)
 	} else {
-		ctx.Warnf("Writing color grading lut")
 		err = WriteColorGradingLut(ctx, &colorGradingDDS)
 	}
 	if err != nil {

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -292,7 +292,8 @@ func AddMaterials(ctx *extractor.Context, doc *gltf.Document, imgOpts *extr_mate
 
 	for id, resID := range unitInfo.Materials {
 		resID = ctx.OverrideMaterial(id, resID)
-		matR, err := ctx.Open(stingray.NewFileID(resID, stingray.Sum("material")), stingray.DataMain)
+		materialId := ctx.OverrideAsset(stingray.NewFileID(resID, stingray.Sum("material")))
+		matR, err := ctx.Open(materialId, stingray.DataMain)
 		if err != nil {
 			return nil, err
 		}
@@ -301,7 +302,7 @@ func AddMaterials(ctx *extractor.Context, doc *gltf.Document, imgOpts *extr_mate
 			return nil, err
 		}
 
-		resPath := ctx.LookupHash(resID)
+		resPath := ctx.LookupHash(materialId.Name)
 		if strings.Contains(resPath, "/") {
 			split := strings.Split(resPath, "/")
 			resPath = strings.Join(split[len(split)-2:], "/")

--- a/stingray/shading_environment/shading_environment.go
+++ b/stingray/shading_environment/shading_environment.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 
 	"github.com/xypwn/filediver/stingray"
 )
@@ -153,7 +152,7 @@ type ShadingEnvironmentEntityToShaderMapping map[stingray.ThinHash]struct {
 	ShaderIndex uint32
 }
 
-func (s ShadingEnvironmentMapping) ToEntityMap(in ShadingEnvironmentEntityToShaderMapping) ShadingEnvironmentEntityToShaderMapping {
+func (s ShadingEnvironmentMapping) ToEntityMap() ShadingEnvironmentEntityToShaderMapping {
 	result := make(ShadingEnvironmentEntityToShaderMapping)
 	for _, entityMapping := range s.EntitySettingMappings {
 		switch entityMapping.SettingType {
@@ -203,7 +202,6 @@ func (s ShadingEnvironmentMapping) ToEntityMap(in ShadingEnvironmentEntityToShad
 			}
 		}
 	}
-	maps.Copy(result, in)
 	return result
 }
 

--- a/stingray/strings/strings.go
+++ b/stingray/strings/strings.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 
 	"github.com/xypwn/filediver/stingray"
+	"golang.org/x/text/language"
 )
 
 var LanguageHashToFriendlyName = map[stingray.ThinHash]string{
@@ -28,6 +29,25 @@ var LanguageHashToFriendlyName = map[stingray.ThinHash]string{
 	stingray.Sum("sc").Thin(): "Chinese (Simplified)",
 	stingray.Sum("tc").Thin(): "Chinese (Traditional)",
 	stingray.Sum("us").Thin(): "English (US)",
+}
+
+var LanguageHashToLanguageTag = map[stingray.ThinHash]language.Tag{
+	stingray.Sum("bp").Thin(): language.BrazilianPortuguese,
+	stingray.Sum("de").Thin(): language.German,
+	stingray.Sum("es").Thin(): language.EuropeanSpanish,
+	stingray.Sum("fr").Thin(): language.French,
+	stingray.Sum("gb").Thin(): language.BritishEnglish,
+	stingray.Sum("it").Thin(): language.Italian,
+	stingray.Sum("jp").Thin(): language.Japanese,
+	stingray.Sum("ko").Thin(): language.Korean,
+	stingray.Sum("ms").Thin(): language.LatinAmericanSpanish,
+	stingray.Sum("nl").Thin(): language.Dutch,
+	stingray.Sum("pl").Thin(): language.Polish,
+	stingray.Sum("pt").Thin(): language.EuropeanPortuguese,
+	stingray.Sum("ru").Thin(): language.Russian,
+	stingray.Sum("sc").Thin(): language.SimplifiedChinese,
+	stingray.Sum("tc").Thin(): language.TraditionalChinese,
+	stingray.Sum("us").Thin(): language.AmericanEnglish,
 }
 
 var LanguageFriendlyNameToHash map[string]stingray.ThinHash


### PR DESCRIPTION
Planets decide which color grading settings to use, so rather than needing to know the exact entity you want, you can now use the planet name to choose how the speedtree should be exported. Additionally, planets can define asset overrides, so I've added support for that as well (the autumn planets override leaf textures to use a maple leaf rather than an oval leaf, for example)

Here's an example of how the GUI looks now when switching between planets: https://youtu.be/3u3hmdjTlK0