### PR TITLE
Terrain Projector Shader

### DIFF
--- a/cmd/tools/components/planet-data-json-dumper/dumper/dumper.go
+++ b/cmd/tools/components/planet-data-json-dumper/dumper/dumper.go
@@ -65,7 +65,7 @@ type SimplePlanetData struct {
 	ResourceRegionOverrides          []SimpleResourceRegionOverride    `json:"resource_region_overrides"`
 	ShadingEnvironmentEntity         string                            `json:"shading_environment_entity"`
 	WaterEntity                      string                            `json:"water_entity"`
-	UnknownHash                      string                            `json:"unknown_hash"`
+	HeathazeEntity                   string                            `json:"heathaze_entity"`
 	PackagePath                      string                            `json:"package_path"`
 	UnknownFloat                     float32                           `json:"unknown_float"`
 }
@@ -155,7 +155,7 @@ func Dump(a components.HashLookup) {
 			ResourceRegionOverrides:          resourceRegionOverrides,
 			ShadingEnvironmentEntity:         a.LookupHash(planetData.ShadingEnvironmentEntity),
 			WaterEntity:                      a.LookupHash(planetData.WaterEntity),
-			UnknownHash:                      a.LookupHash(planetData.UnknownHash),
+			HeathazeEntity:                   a.LookupHash(planetData.HeathazeEntity),
 			PackagePath:                      a.LookupHash(planetData.PackagePath),
 			UnknownFloat:                     planetData.UnknownFloat,
 		}

--- a/datalibrary/planet_data.go
+++ b/datalibrary/planet_data.go
@@ -110,7 +110,7 @@ type rawPlanetData struct {
 	ResourceRegionOverridesCount     uint64
 	ShadingEnvironmentEntity         stingray.Hash
 	WaterEntity                      stingray.Hash
-	UnknownHash                      stingray.Hash
+	HeathazeEntity                   stingray.Hash
 	PackagePath                      stingray.Hash
 	UnknownFloat                     float32
 	_                                [4]uint8
@@ -162,7 +162,7 @@ type PlanetData struct {
 	ResourceRegionOverrides          []ResourceRegionOverride
 	ShadingEnvironmentEntity         stingray.Hash
 	WaterEntity                      stingray.Hash
-	UnknownHash                      stingray.Hash
+	HeathazeEntity                   stingray.Hash
 	PackagePath                      stingray.Hash
 	UnknownFloat                     float32
 }
@@ -192,7 +192,7 @@ func (a rawPlanetData) Resolve(lookupHash HashLookup, lookupThinHash ThinHashLoo
 		PlanetPreviewImage:               a.PlanetPreviewImage,
 		ShadingEnvironmentEntity:         a.ShadingEnvironmentEntity,
 		WaterEntity:                      a.WaterEntity,
-		UnknownHash:                      a.UnknownHash,
+		HeathazeEntity:                   a.HeathazeEntity,
 		PackagePath:                      a.PackagePath,
 		UnknownFloat:                     a.UnknownFloat,
 	}

--- a/extractor/entity/extractor.go
+++ b/extractor/entity/extractor.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -471,6 +472,28 @@ func WriteDDSColorGradingLut(w io.Writer, entityInfo *entity.Entity) error {
 	return writeDDS(w, colorGradingLut)
 }
 
-func WriteDDSIdentityColorGradingLut(w io.Writer) error {
+func writeDDSIdentityColorGradingLut(w io.Writer) error {
 	return writeDDS(w, CreateIdentityColorGradingLut())
+}
+
+func WriteColorGradingLut(ctx *extractor.Context, colorGradingDDS *bytes.Buffer) error {
+	entityID := stingray.NewFileID(ctx.ColorGrading(), stingray.Sum("entity"))
+	if !ctx.Exists(entityID, stingray.DataMain) {
+		writeDDSIdentityColorGradingLut(colorGradingDDS)
+		if entityID.Name.Value == 0x0 {
+			return nil
+		}
+		return fmt.Errorf("entity %v does not exist", entityID.Name.String())
+	}
+	entityData, err := ctx.Open(entityID, stingray.DataMain)
+	if err != nil {
+		writeDDSIdentityColorGradingLut(colorGradingDDS)
+		return err
+	}
+	entityInfo, err := entity.LoadEntity(entityData, ctx.EntityVarMapping())
+	if err != nil {
+		writeDDSIdentityColorGradingLut(colorGradingDDS)
+		return err
+	}
+	return WriteDDSColorGradingLut(colorGradingDDS, entityInfo)
 }

--- a/extractor/material/extractor.go
+++ b/extractor/material/extractor.go
@@ -800,6 +800,21 @@ func checkBuildingShaderDecalUV(ctx *extractor.Context, mat *material.Material) 
 	return 0, nil
 }
 
+func AddColorGradingLUT(ctx *extractor.Context, doc *gltf.Document, colorGradingDDS bytes.Buffer, matInfo *material.Material) {
+	colorGradingName := ctx.ColorGrading()
+	if ctx.ColorGrading().Value == 0x0 {
+		colorGradingName = stingray.Sum("identity")
+	}
+	colorGradingId := stingray.NewFileID(colorGradingName, stingray.Sum("texture"))
+	colorGradingOpts := &ImageOptions{PngCompression: png.DefaultCompression, Jpeg: false, Raw: true}
+	_, err := WriteDDS(ctx.WithFileID(colorGradingId), doc, bytes.NewReader(colorGradingDDS.Bytes()), nil, colorGradingOpts, "")
+	if err != nil {
+		ctx.Warnf("Speedtree: writing asset grading lut to document: %v", err)
+	}
+
+	matInfo.Textures[stingray.Sum("asset_color_grading_lut").Thin()] = colorGradingName
+}
+
 func AddMaterial(ctx *extractor.Context, mat *material.Material, doc *gltf.Document, imgOpts *ImageOptions, matSlot stingray.ThinHash, matName string, unitData *datalib.UnitData) (uint32, error) {
 	cfg := ctx.Config()
 

--- a/extractor/material/extractor.go
+++ b/extractor/material/extractor.go
@@ -839,13 +839,7 @@ func AddMaterial(ctx *extractor.Context, mat *material.Material, doc *gltf.Docum
 			continue
 		}
 		switch texUsageStr {
-		case "tex0":
-			fallthrough
-		case "color_roughness":
-			fallthrough
-		case "color_specular_b":
-			fallthrough
-		case "albedo_iridescence":
+		case "albedo_iridescence", "tex0", "color_roughness", "color_specular_b", "albedo_blend_tex", "albedo_tex":
 			albedoPostProcess = nil
 			fallthrough
 		case "covering_albedo":
@@ -1054,9 +1048,7 @@ func AddMaterial(ctx *extractor.Context, mat *material.Material, doc *gltf.Docum
 				usedTextures[texUsageStr] = index
 			}
 			albedoPostProcess = postProcessToOpaque
-		case "base_data":
-			fallthrough
-		case "normal_specular_ao":
+		case "normal_specular_ao", "base_data", "nar_tex":
 			// GLTF normals will look wonky, but our own material will be able to use the specular+ao in this map
 			// in blender
 			normalPostProcess = nil
@@ -1307,91 +1299,7 @@ func AddMaterial(ctx *extractor.Context, mat *material.Material, doc *gltf.Docum
 			}
 			usedTextures[texUsageStr] = index
 			imgOpts = origImgOpts
-		case "composite_array":
-			fallthrough
-		case "customization_camo_tiler_array":
-			fallthrough
-		case "customization_material_detail_tiler_array":
-			fallthrough
-		case "decal_sheet":
-			fallthrough
-		case "id_masks_array":
-			fallthrough
-		case "Detail_Data":
-			fallthrough
-		case "surface_data_array":
-			fallthrough
-		case "pattern_data":
-			fallthrough
-		case "texture_map_319d3bb5":
-			fallthrough
-		case "metal_surface_data":
-			fallthrough
-		case "concrete_surface_data":
-			fallthrough
-		case "bcm_tex_a":
-			fallthrough
-		case "bcm_tex_b":
-			fallthrough
-		case "nar_tex_a":
-			fallthrough
-		case "nar_tex_b":
-			fallthrough
-		case "blend_tex_mask":
-			fallthrough
-		case "mask":
-			fallthrough
-		case "albedo_array":
-			fallthrough
-		case "normal_array":
-			fallthrough
-		case "emissive":
-			fallthrough
-		case "noise_map_01":
-			fallthrough
-		case "noise_map_02":
-			fallthrough
-		case "edge_noise_map":
-			fallthrough
-		case "grayscale_skin":
-			fallthrough
-		case "noise_tiler_mask":
-			fallthrough
-		case "base_tiler_nar":
-			fallthrough
-		case "base_tiler_nan":
-			fallthrough
-		case "detail_trimsheet_metallic_ceramic_masking":
-			fallthrough
-		case "ceramic_detail_tiler_basecolor":
-			fallthrough
-		case "ceramic_detail_tiler_nar":
-			fallthrough
-		case "rock_detail_tiler_basecolor":
-			fallthrough
-		case "rock_detail_tiler_nar":
-			fallthrough
-		case "detail_trimsheet_nar":
-			fallthrough
-		case "metallic_lut":
-			fallthrough
-		case "blood_splatter_tiler":
-			fallthrough
-		case "bug_splatter_tiler":
-			fallthrough
-		case "weathering_dirt":
-			fallthrough
-		case "weathering_special":
-			fallthrough
-		case "cape_tear":
-			fallthrough
-		case "cape_scalar_fields":
-			fallthrough
-		case "cape_gradient":
-			fallthrough
-		case "emissive_texture":
-			fallthrough
-		case "pattern_masks_array":
+		case "emissive_texture", "displacement_tex", "snow_mask_texture", "glint_sample", "pattern_masks_array", "composite_array", "customization_camo_tiler_array", "customization_material_detail_tiler_array", "decal_sheet", "id_masks_array", "Detail_Data", "surface_data_array", "pattern_data", "texture_map_319d3bb5", "metal_surface_data", "concrete_surface_data", "bcm_tex_a", "bcm_tex_b", "nar_tex_a", "nar_tex_b", "blend_tex_mask", "mask", "albedo_array", "normal_array", "emissive", "noise_map_01", "noise_map_02", "edge_noise_map", "grayscale_skin", "noise_tiler_mask", "base_tiler_nar", "base_tiler_nan", "detail_trimsheet_metallic_ceramic_masking", "ceramic_detail_tiler_basecolor", "ceramic_detail_tiler_nar", "rock_detail_tiler_basecolor", "rock_detail_tiler_nar", "detail_trimsheet_nar", "metallic_lut", "blood_splatter_tiler", "bug_splatter_tiler", "weathering_dirt", "weathering_special", "cape_tear", "cape_scalar_fields", "cape_gradient":
 			hash := mat.Textures[texUsage]
 			if unitData != nil && texUsageStr == "decal_sheet" && unitData.DecalSheet.Value != 0 {
 				hash = unitData.DecalSheet
@@ -1907,7 +1815,7 @@ func ConvertToFolder(ctx *extractor.Context) error {
 			}
 			for j := range shaderProgram.Headers[i].Stages {
 				stageMask := material.ShaderStageMask(1 << j)
-				if stageMask&shaderProgram.Headers[i].StageMask == material.ShaderStage_None {
+				if stageMask&shaderProgram.Headers[i].StageMask == material.ShaderStage_None && shaders[j] == nil {
 					continue
 				}
 				suffixArray, err := stageMask.Suffix()

--- a/extractor/speedtree/extractor.go
+++ b/extractor/speedtree/extractor.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"image/png"
 	"io"
 	"strings"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/xypwn/filediver/extractor/geometry"
 	extr_material "github.com/xypwn/filediver/extractor/material"
 	"github.com/xypwn/filediver/stingray"
-	"github.com/xypwn/filediver/stingray/entity"
 	"github.com/xypwn/filediver/stingray/speedtree"
 	"github.com/xypwn/filediver/stingray/unit"
 	"github.com/xypwn/filediver/stingray/unit/material"
@@ -207,25 +205,6 @@ func AddPrefabMetadata(ctx *extractor.Context, doc *gltf.Document, root *uint32,
 	doc.Extras = extras
 }
 
-func WriteColorGradingLut(ctx *extractor.Context, colorGradingDDS *bytes.Buffer) error {
-	entityID := stingray.NewFileID(ctx.ColorGrading(), stingray.Sum("entity"))
-	if !ctx.Exists(entityID, stingray.DataMain) {
-		extr_entity.WriteDDSIdentityColorGradingLut(colorGradingDDS)
-		return fmt.Errorf("entity %v does not exist", entityID.Name.String())
-	}
-	entityData, err := ctx.Open(entityID, stingray.DataMain)
-	if err != nil {
-		extr_entity.WriteDDSIdentityColorGradingLut(colorGradingDDS)
-		return err
-	}
-	entityInfo, err := entity.LoadEntity(entityData, ctx.EntityVarMapping())
-	if err != nil {
-		extr_entity.WriteDDSIdentityColorGradingLut(colorGradingDDS)
-		return err
-	}
-	return extr_entity.WriteDDSColorGradingLut(colorGradingDDS, entityInfo)
-}
-
 func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gltfDoc *gltf.Document) error {
 	cfg := ctx.Config()
 	if cfg.SpeedTree.Format == "json" {
@@ -255,12 +234,7 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 	}
 
 	var colorGradingDDS bytes.Buffer
-	if ctx.ColorGrading().Value == 0x0 {
-		err = extr_entity.WriteDDSIdentityColorGradingLut(&colorGradingDDS)
-	} else {
-		err = WriteColorGradingLut(ctx, &colorGradingDDS)
-	}
-	if err != nil {
+	if err = extr_entity.WriteColorGradingLut(ctx, &colorGradingDDS); err != nil {
 		ctx.Warnf("Writing color grading lut: %v", err)
 	}
 
@@ -283,18 +257,7 @@ func ConvertOpts(ctx *extractor.Context, imgOpts *extr_material.ImageOptions, gl
 			split := strings.Split(matPath, "/")
 			matPath = strings.Join(split[len(split)-2:], "/")
 		}
-		colorGradingName := ctx.ColorGrading()
-		if ctx.ColorGrading().Value == 0x0 {
-			colorGradingName = stingray.Sum("identity")
-		}
-		colorGradingId := stingray.NewFileID(colorGradingName, stingray.Sum("texture"))
-		colorGradingOpts := &extr_material.ImageOptions{PngCompression: png.DefaultCompression, Jpeg: false, Raw: true}
-		_, err = extr_material.WriteDDS(ctx.WithFileID(colorGradingId), doc, bytes.NewReader(colorGradingDDS.Bytes()), nil, colorGradingOpts, "")
-		if err != nil {
-			ctx.Warnf("Speedtree: writing asset grading lut to document: %v", err)
-		}
-
-		matInfo.Textures[stingray.Sum("asset_color_grading_lut").Thin()] = colorGradingName
+		extr_material.AddColorGradingLUT(ctx, doc, colorGradingDDS, matInfo)
 
 		matIdx, err := extr_material.AddMaterial(ctx, matInfo, doc, imgOpts, stingray.Sum("speedtree").Thin(), treeInfo.SDKMaterials[mat.Index].Name+fmt.Sprintf(" %v", matPath), nil)
 		if err != nil {

--- a/extractor/unit/extractor.go
+++ b/extractor/unit/extractor.go
@@ -1,6 +1,7 @@
 package unit
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -20,6 +21,7 @@ import (
 	datalib "github.com/xypwn/filediver/datalibrary"
 	"github.com/xypwn/filediver/datalibrary/enum"
 	"github.com/xypwn/filediver/extractor"
+	extr_entity "github.com/xypwn/filediver/extractor/entity"
 	"github.com/xypwn/filediver/extractor/geometry"
 	extr_material "github.com/xypwn/filediver/extractor/material"
 	"github.com/xypwn/filediver/extractor/state_machine"
@@ -291,6 +293,11 @@ func AddMaterials(ctx *extractor.Context, doc *gltf.Document, imgOpts *extr_mate
 	equipmentData, _ := datalib.GetEquipmentComponentDataForHash(weaponHash)
 	isHelldiverWeapon := len(equipmentData) > 0
 
+	var colorGradingDDS bytes.Buffer
+	if err := extr_entity.WriteColorGradingLut(ctx, &colorGradingDDS); err != nil {
+		ctx.Warnf("Writing color grading lut: %v", err)
+	}
+
 	for id, resID := range unitInfo.Materials {
 		resID = ctx.OverrideMaterial(id, resID)
 		materialId := ctx.OverrideAsset(stingray.NewFileID(resID, stingray.Sum("material")))
@@ -301,6 +308,11 @@ func AddMaterials(ctx *extractor.Context, doc *gltf.Document, imgOpts *extr_mate
 		mat, err := material.LoadMain(matR)
 		if err != nil {
 			return nil, err
+		}
+
+		materialSlot := ctx.LookupThinHash(id)
+		if strings.HasPrefix(materialSlot, "projector") {
+			extr_material.AddColorGradingLUT(ctx, doc, colorGradingDDS, mat)
 		}
 
 		resPath := ctx.LookupHash(materialId.Name)

--- a/hashes/cracked.txt
+++ b/hashes/cracked.txt
@@ -3097,6 +3097,9 @@ content/env_illuminate/prefabs/il_cables_merged_05
 content/env_illuminate/prefabs/il_cables_merged_06
 content/env_illuminate/props/il_battery_machine_01
 content/env_illuminate/props/il_battery_machine_base
+content/env_illuminate/props/il_battery_machine_single_01
+content/env_illuminate/props/il_cable_attach_object_01
+content/env_illuminate/props/il_cable_attach_object_02
 content/env_illuminate/props/il_canister
 content/env_illuminate/props/il_circular_platform_01
 content/env_illuminate/props/il_container_01
@@ -3112,6 +3115,9 @@ content/env_illuminate/props/il_cover_wall_end_01
 content/env_illuminate/props/il_cover_wall_end_02
 content/env_illuminate/props/il_cover_wall_end_03
 content/env_illuminate/props/il_cover_wall_end_04
+content/env_illuminate/props/il_misc_machine_01
+content/env_illuminate/props/il_misc_machine_02
+content/env_illuminate/props/il_misc_machine_connector
 content/env_illuminate/props/il_mobile_cover
 content/env_illuminate/props/il_satellite_01
 content/env_illuminate/props/il_signpost

--- a/hashes/hashes.txt
+++ b/hashes/hashes.txt
@@ -91154,6 +91154,9 @@ content/env_illuminate/prefabs/il_cables_merged_05
 content/env_illuminate/prefabs/il_cables_merged_06
 content/env_illuminate/props/il_battery_machine_01
 content/env_illuminate/props/il_battery_machine_base
+content/env_illuminate/props/il_battery_machine_single_01
+content/env_illuminate/props/il_cable_attach_object_01
+content/env_illuminate/props/il_cable_attach_object_02
 content/env_illuminate/props/il_canister
 content/env_illuminate/props/il_circular_platform_01
 content/env_illuminate/props/il_container_01
@@ -91169,6 +91172,9 @@ content/env_illuminate/props/il_cover_wall_end_01
 content/env_illuminate/props/il_cover_wall_end_02
 content/env_illuminate/props/il_cover_wall_end_03
 content/env_illuminate/props/il_cover_wall_end_04
+content/env_illuminate/props/il_misc_machine_01
+content/env_illuminate/props/il_misc_machine_02
+content/env_illuminate/props/il_misc_machine_connector
 content/env_illuminate/props/il_mobile_cover
 content/env_illuminate/props/il_satellite_01
 content/env_illuminate/props/il_signpost

--- a/hashes/thinhashes.txt
+++ b/hashes/thinhashes.txt
@@ -32122,3 +32122,4 @@ emissive_distance_bias
 emissive_intensity
 emissive_height_fade_exponent
 emissive_invert_ao_range
+shadow_rubble

--- a/scripts/cubemap_to_equirectangular.py
+++ b/scripts/cubemap_to_equirectangular.py
@@ -1,0 +1,131 @@
+from dds_float16 import DDS
+from openexr.types import OpenEXR
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+from pathlib import Path
+from argparse import ArgumentParser
+
+magnitude = 0.1
+perturb = [
+    Rotation.from_rotvec([magnitude, 0, 0], degrees=True),
+    Rotation.from_rotvec([-magnitude, 0, 0], degrees=True),
+    Rotation.from_rotvec([0, 0, magnitude], degrees=True),
+    Rotation.from_rotvec([0, 0, -magnitude], degrees=True),
+    Rotation.from_rotvec([magnitude, 0, magnitude], degrees=True),
+    Rotation.from_rotvec([magnitude, 0, -magnitude], degrees=True),
+    Rotation.from_rotvec([-magnitude, 0, magnitude], degrees=True),
+    Rotation.from_rotvec([-magnitude, 0, -magnitude], degrees=True),
+    Rotation.from_rotvec([0, magnitude, 0], degrees=True),
+    Rotation.from_rotvec([0, -magnitude, 0], degrees=True),
+    Rotation.from_rotvec([magnitude, magnitude, 0], degrees=True),
+    Rotation.from_rotvec([magnitude, -magnitude, 0], degrees=True),
+    Rotation.from_rotvec([-magnitude, magnitude, 0], degrees=True),
+    Rotation.from_rotvec([-magnitude, -magnitude, 0], degrees=True),
+]
+
+@np.vectorize(excluded={1, 'pixels'}, signature='(n)->(m)')
+def sample_cubemap(vec: np.ndarray, pixels: np.ndarray) -> np.ndarray:
+    assert vec.shape[0] == 3, f"Expected 3d vectors got {vec.shape}"
+    assert pixels.ndim == 4 and pixels.shape[0] == 6, "Expected cubemap pixels"
+
+    a: float = abs(vec).max()
+    vecA: np.ndarray = vec / a
+
+    cubeFaceWidth, cubeFaceHeight = pixels.shape[2], pixels.shape[1]
+    if vecA[0] == 1.0 or vecA[0] == -1.0:
+        # right / left
+        face = 0 if vecA[0] == 1.0 else 1
+        offset = -1.0 if vecA[0] == 1.0 else 0.0
+        xPixel = int((((vecA[2] + 1.0) / 2.0) + offset) * cubeFaceWidth)
+        yPixel = int((((vecA[1] + 1.0) / 2.0)) * cubeFaceHeight)
+    elif vecA[1] == 1.0 or vecA[1] == -1.0:
+        # up / down
+        face = 2 if vecA[1] == 1.0 else 3
+        offset = -1.0 if vecA[1] == 1.0 else 0.0
+        xPixel = int((((vecA[0] + 1.0) / 2.0)) * cubeFaceWidth)
+        yPixel = int((((vecA[2] + 1.0) / 2.0) + offset) * cubeFaceHeight)
+    elif vecA[2] == 1.0 or vecA[2] == -1.0:
+        # front / back
+        face = 4 if vecA[2] == 1.0 else 5
+        offset = -1.0 if vecA[2] == -1.0 else 0.0
+        xPixel = int((((vecA[0] + 1.0) / 2.0) + offset) * cubeFaceWidth)
+        yPixel = int((((vecA[1] + 1.0) / 2.0)) * cubeFaceHeight)
+
+    xPixel = max(min(abs(xPixel), cubeFaceWidth-1), 0)
+    yPixel = max(min(abs(yPixel), cubeFaceHeight-1), 0)
+    return pixels[face, yPixel, xPixel]
+
+def normalize(vec: np.ndarray) -> np.ndarray:
+    return vec / np.sqrt((vec**2).sum())
+
+def make_tile(color: np.ndarray) -> np.ndarray:
+    assert color.ndim == 1 and color.shape[0] == 4
+    dim = color * 0.25
+    return np.array([[color, dim], [dim, color]], dtype=color.dtype)
+
+def build_equirectangular(height: int, width: int, pixels: np.ndarray) -> np.ndarray:
+    output = np.zeros((height, width, 4), dtype=pixels.dtype)
+    for j in range(output.shape[0]):
+        v = 1.0 - float(j) / output.shape[0]
+        theta = v * np.pi
+        print(f"{j+1}/{output.shape[0]}")
+
+        for i in range(output.shape[1]):
+            u = float(i) / output.shape[1]
+            phi = u * 2 * np.pi
+
+            x = np.sin(phi) * np.sin(theta) * -1.0
+            y = np.cos(theta)
+            z = np.cos(phi) * np.sin(theta) * -1.0
+
+            perturbed = np.array([np.array([x, y, z])])
+            samples = sample_cubemap(perturbed, pixels)
+            # for p in perturb:
+            #     samples.append(sample_cubemap(, pixels))
+            output[j, i] = np.average(samples, axis=0)
+    return output
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("path", type=Path)
+    parser.add_argument("output_width", type=int)
+    args = parser.parse_args()
+
+    path: Path = args.path
+
+    with path.open("rb") as f:
+        pixels = DDS.parse(f).pixels()
+
+    red = np.array([1, 0, 0, 1], dtype=np.float16)
+    green = np.array([0, 1, 0, 1], dtype=np.float16)
+    blue = np.array([0, 0, 1, 1], dtype=np.float16)
+    magenta = np.array([1, 0, 1, 1], dtype=np.float16)
+    yellow = np.array([1, 1, 0, 1], dtype=np.float16)
+    cyan = np.array([0, 1, 1, 1], dtype=np.float16)
+
+    _ = np.array([
+        make_tile(red), # +x
+        make_tile(green), # -x
+        make_tile(blue), # -y
+        make_tile(magenta), # +y
+        make_tile(yellow), # +z
+        make_tile(cyan), # -z
+    ], dtype=np.float16)
+
+    faces = pixels[[0, 1, 5, 4, 3, 2]]
+    faces[2] = faces[2,::-1,::-1]
+    faces[0] = np.rot90(faces[0], 3)
+    faces[1] = np.rot90(faces[1])
+    faces[5] = np.rot90(faces[5], 2)
+    output_height = args.output_width >> 1
+
+    output = build_equirectangular(output_height, args.output_width, faces)
+
+    exr = OpenEXR.from_pixels(output).serialize()
+    exr_path = path.with_suffix(".equirectangular.exr")
+    with exr_path.open("wb") as f:
+        f.write(exr)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dds_float16.py
+++ b/scripts/dds_float16.py
@@ -167,6 +167,44 @@ class DDSPixelFormat:
         size, flags, fourcc, bitcount, redmask, grnmask, blumask, alpmask = struct.unpack("<II4sIIIII", data.read(32))
         return cls(size, flags, fourcc, bitcount, redmask, grnmask, blumask, alpmask)
 
+
+"""
+bitfield Caps2Flags {
+  padding        : 9;
+  cubemap        : 1;
+  cubemap_plusX  : 1;
+  cubemap_minusX : 1;
+  cubemap_plusY  : 1;
+  cubemap_minusY : 1;
+  cubemap_plusZ  : 1;
+  cubemap_minusZ : 1;
+  padding        : 5;
+  volume         : 1; // 0x200000
+  padding        : 10;
+};
+"""
+
+class DDSCaps2:
+    def __init__(self, value: int):
+        self.value = value
+
+    def cubemap(self) -> bool:
+        return self.value & (1 << 9) != 0
+    def cubemap_plusX(self) -> bool:
+        return self.value & (1 << 10) != 0
+    def cubemap_minusX(self) -> bool:
+        return self.value & (1 << 11) != 0
+    def cubemap_plusY(self) -> bool:
+        return self.value & (1 << 12) != 0
+    def cubemap_minusY(self) -> bool:
+        return self.value & (1 << 13) != 0
+    def cubemap_plusZ(self) -> bool:
+        return self.value & (1 << 14) != 0
+    def cubemap_minusZ(self) -> bool:
+        return self.value & (1 << 15) != 0
+    def volume(self) -> bool:
+        return self.value & (1 << 21) != 0
+
 class DDSHeader:
     def __init__(self, magic: bytes, size: int, flags: int, height: int, width: int, pitch: int, depth: int, mipmaps: int, dds_pix_fmt: DDSPixelFormat, caps: int, caps2: int, caps3: int, caps4: int, dx10header: DX10Header):
         self.magic = magic
@@ -179,7 +217,7 @@ class DDSHeader:
         self.mipmaps = mipmaps
         self.dds_pix_fmt = dds_pix_fmt
         self.caps = caps
-        self.caps2 = caps2
+        self.caps2 = DDSCaps2(caps2)
         self.caps3 = caps3
         self.caps4 = caps4
         self.dx10header = dx10header
@@ -210,6 +248,13 @@ class DDS:
     def parse(cls, data: BytesIO) -> 'DDS':
         return cls(DDSHeader.parse(data), data.read())
 
+    def read_face(self, width, height, offset, stride, fmt, conv):
+        face = []
+        for _ in range(height):
+            face.append([conv(pixel) for pixel in struct.iter_unpack(fmt, self.data[offset:offset + stride * width])])
+            offset += stride * width
+        return face, offset
+
     # Returns the largest mipmap's pixels
     def pixels(self) -> np.ndarray:
         assert self.header.dds_pix_fmt.fourcc == b"DX10", f"Pixel format not DX10: got '{self.header.dds_pix_fmt.fourcc}'"
@@ -225,8 +270,23 @@ class DDS:
                 conv = lambda x: tuple(float(val) / 255 for val in x)
         offset = 0
         pixels = []
-        for _ in range(self.header.height):
-            pixels.append([conv(pixel) for pixel in struct.iter_unpack(fmt, self.data[offset:offset + stride * self.header.width])])
-            offset += stride * self.header.width
+        faces = []
+        layers = self.header.dx10header.arraysize
+        if self.header.caps2.cubemap():
+            layers = 6
+        for _ in range(layers):
+            mip_width, mip_height = self.header.width, self.header.height
+            for _ in range(self.header.mipmaps):
+                face, offset = self.read_face(mip_width, mip_height, offset, stride, fmt, conv)
+                faces.append(face)
+                mip_width >>= 1
+                mip_height >>= 1
+            if layers == 1:
+                pixels = faces[0]
+            else:
+                pixels.append(faces[0])
+            faces = []
+
+        
         return np.array(pixels, dtype=np.float16)
 

--- a/scripts/hd2_accurate_blender_importer.py
+++ b/scripts/hd2_accurate_blender_importer.py
@@ -49,6 +49,7 @@ material_loaders: List[FilediverMaterialLoaderInterface] = [
     PortalMaterialLoader(),
     SkinMaterialLoader(),
     SpeedtreeMaterialLoader(),
+    TerrainMaterialLoader(),
 ]
 
 class IDPropertyUIManager:

--- a/scripts/material_loaders/__init__.py
+++ b/scripts/material_loaders/__init__.py
@@ -13,6 +13,7 @@ from .lut_skin_material_loader import LutSkinMaterialLoader
 from .portal_material_loader import PortalMaterialLoader
 from .skin_material_loader import SkinMaterialLoader
 from .speedtree_material_loader import SpeedtreeMaterialLoader
+from .terrain_material_loader import TerrainMaterialLoader
 
 __all__ = [
     "FilediverMaterialLoaderInterface",
@@ -29,4 +30,5 @@ __all__ = [
     "PortalMaterialLoader",
     "SkinMaterialLoader",
     "SpeedtreeMaterialLoader",
+    "TerrainMaterialLoader",
 ]

--- a/scripts/material_loaders/terrain_material_loader.py
+++ b/scripts/material_loaders/terrain_material_loader.py
@@ -1,0 +1,76 @@
+from .filediver_material_loader_interface import FilediverMaterialLoaderInterface
+
+from typing import Dict, Optional
+
+from bpy.types import (
+    BlendData,
+    Material,
+    ShaderNodeTexImage,
+    ShaderNodeGroup,
+)
+import bpy
+
+class TerrainMaterialLoader(FilediverMaterialLoaderInterface):
+    material: Material = None
+
+    def load_material(self, resource_path: str) -> None:
+        if f"HD2 {self.key()}" not in bpy.data.materials:
+            with bpy.data.libraries.load(str(resource_path / "Helldivers2 Shader v1.0.5.blend")) as (shader_blend, our_blend):
+                our_blend: BlendData # not actually but they share member names 
+                shader_blend: BlendData
+                our_blend.materials = shader_blend.materials
+        self.material = bpy.data.materials[f"HD2 {self.key()}"]
+        self.material.use_fake_user = True
+
+    def add_material(self, config: dict, textures: Dict[str, bpy.types.Image]) -> bpy.types.Material:
+        object_mat = self.material.copy()
+        object_mat.name = f"HD2 {self.key()} " + config["name"]
+
+        print("    Applying textures")
+        config_nodes: Dict[str, ShaderNodeTexImage|ShaderNodeGroup] = object_mat.node_tree.nodes
+        asset_color_grading_lut_group: Dict[str, ShaderNodeTexImage] = bpy.data.node_groups["asset_color_grading_lut"].nodes
+
+        for usage, image in textures.items():
+            match usage:
+                case "albedo_blend_tex" | "albedo_tex":
+                    config_nodes["Image Texture"].image = image
+                    image.colorspace_settings.name = "Non-Color"
+                    image.alpha_mode = "CHANNEL_PACKED"
+                case "displacement_tex":
+                    config_nodes["Image Texture.001"].image = image
+                    image.colorspace_settings.name = "Non-Color"
+                case "nar_tex":
+                    config_nodes["Image Texture.002"].image = image
+                    image.colorspace_settings.name = "Non-Color"
+                case "asset_color_grading_lut":
+                    asset_color_grading_lut_group["Image Texture"].image = image
+                    image.colorspace_settings.name = "Non-Color"
+                    asset_color_grading_lut_group["Image Texture"].interpolation = "Closest"
+        print("    Finalizing material")
+
+        for name, setting in config["extras"].items():
+            object_mat[name] = setting
+            if name not in config_nodes["Terrain Color Grading"].inputs:
+                continue
+            config_nodes["Terrain Color Grading"].inputs[name].default_value = setting[0]
+
+        object_mat["needsBakeUVs"] = False
+        return object_mat
+
+    @classmethod
+    def can_configure(cls, config: dict) -> bool:
+        return ("albedo_blend_tex" in config["extras"] or "albedo_tex") and "nar_tex" in config["extras"] and "asset_color_grading_lut" in config["extras"]
+
+    @classmethod
+    def key(cls) -> str:
+        return "Terrain"
+
+    def get_material(self, config: dict, index: int) -> Optional[bpy.types.Material]:
+        key = f"HD2 {self.key()} " + config["name"]
+        i = 1
+        while key in bpy.data.materials and bpy.data.materials[key]["gltfId"] != index:
+            key = f"HD2 {self.key()} " + config["name"] + f".{i:03d}"
+            i += 1
+        if key in bpy.data.materials:
+            return bpy.data.materials[key]
+        return None

--- a/scripts/material_loaders/terrain_material_loader.py
+++ b/scripts/material_loaders/terrain_material_loader.py
@@ -34,7 +34,7 @@ class TerrainMaterialLoader(FilediverMaterialLoaderInterface):
             match usage:
                 case "albedo_blend_tex" | "albedo_tex":
                     config_nodes["Image Texture"].image = image
-                    image.colorspace_settings.name = "Non-Color"
+                    image.colorspace_settings.name = "sRGB"
                     image.alpha_mode = "CHANNEL_PACKED"
                 case "displacement_tex":
                     config_nodes["Image Texture.001"].image = image
@@ -50,9 +50,15 @@ class TerrainMaterialLoader(FilediverMaterialLoaderInterface):
 
         for name, setting in config["extras"].items():
             object_mat[name] = setting
-            if name not in config_nodes["Terrain Color Grading"].inputs:
-                continue
-            config_nodes["Terrain Color Grading"].inputs[name].default_value = setting[0]
+            if name in config_nodes["Terrain Color Grading"].inputs:
+                config_nodes["Terrain Color Grading"].inputs[name].default_value = setting[0]
+            if name in config_nodes["Terrain Emissive"].inputs:
+                if name in ["emissive_base_color_tint", "emissive_color_ao"]:
+                    config_nodes["Terrain Emissive"].inputs[name].default_value = setting[:3]
+                elif name in ["emissive_base_color_luminance_range", "emissive_ao_range"]:
+                    config_nodes["Terrain Emissive"].inputs[name].default_value = setting[:2]
+                else:
+                    config_nodes["Terrain Emissive"].inputs[name].default_value = setting[0]
 
         object_mat["needsBakeUVs"] = False
         return object_mat

--- a/scripts/openexr/types.py
+++ b/scripts/openexr/types.py
@@ -452,7 +452,7 @@ class OpenEXR:
         splits = [i+16 for i in range(0, height-16, 16)]
         if len(splits) == 0:
             splits = [16]
-        scanline_pixels = np.vsplit(faces[f], splits)
+        scanline_pixels = np.vsplit(pixels, splits)
         scanlines: List[Scanline] = []
         y_coord = 0
         for line in scanline_pixels:

--- a/scripts/openexr/types.py
+++ b/scripts/openexr/types.py
@@ -449,7 +449,10 @@ class OpenEXR:
         attributes["screenWindowCenter"] = (0.0, 0.0)
         attributes["screenWindowWidth"] = 1.0
 
-        scanline_pixels = np.vsplit(pixels, [16])
+        splits = [i+16 for i in range(0, height-16, 16)]
+        if len(splits) == 0:
+            splits = [16]
+        scanline_pixels = np.vsplit(faces[f], splits)
         scanlines: List[Scanline] = []
         y_coord = 0
         for line in scanline_pixels:
@@ -463,7 +466,7 @@ class OpenEXR:
         else:
             compression = scanlines[0].best_compression()
             attributes["compression"] = compression
-        
+
         for scanline in scanlines:
             scanline.compress(attributes)
 

--- a/scripts/openexr_builder.py
+++ b/scripts/openexr_builder.py
@@ -38,7 +38,8 @@ def main():
                 with file.open("rb") as f:
                     dds = DDS.parse(f)
                 pixels = dds.pixels().astype(np.float32)
-            except (AssertionError, OSError):
+            except (AssertionError, OSError) as e:
+                print(f"error: {e}")
                 pass
         elif file.suffix == ".csv" and nsight:
             print("csv")
@@ -57,10 +58,17 @@ def main():
                 print(pixels.shape)
         else:
             continue
-        exr = OpenEXR.from_pixels(pixels).serialize()
-        exr_path = file.with_suffix(".exr")
-        with exr_path.open("wb") as f:
-            f.write(exr)
+        if len(pixels.shape) == 4:
+            for i in range(pixels.shape[0]):
+                exr = OpenEXR.from_pixels(pixels[i]).serialize()
+                exr_path = file.with_suffix(f".{i:03d}.exr")
+                with exr_path.open("wb") as f:
+                    f.write(exr)
+        else:
+            exr = OpenEXR.from_pixels(pixels).serialize()
+            exr_path = file.with_suffix(".exr")
+            with exr_path.open("wb") as f:
+                f.write(exr)
 
 def decode_nsight_data(data: List[List[int]], width: int, height: int):
     pixels = [struct.unpack("<eeee", struct.pack("<HHHH", *line)) for line in data]

--- a/stingray/unit/material/material.go
+++ b/stingray/unit/material/material.go
@@ -525,7 +525,7 @@ func LoadGPU(r io.ReadSeeker) (*MaterialGPU, error) {
 				SamplerAttrs: samplerAttrs,
 			})
 
-			if (block.Headers[i].StageMask&ShaderStage_Vertex != 0 || block.Headers[i].StageMask&ShaderStage_Tessellation != 0) && block.Headers[i].Stages[0].DXBCSize > 0 {
+			if (block.Headers[i].StageMask&ShaderStage_Vertex != 0 || block.Headers[i].StageMask&ShaderStage_Tessellation != 0 || (block.Headers[i].StageMask&ShaderStage_Vertex == 0 && block.Headers[i].StageMask&ShaderStage_InstancedVertex == 0)) && block.Headers[i].Stages[0].DXBCSize > 0 {
 				stage := block.Headers[i].Stages[ShaderStage_Vertex.StageIdx()]
 				if shader, ok := loadedShaders[stage.DXBCName]; ok {
 					block.Programs[i].VertexShader = shader

--- a/stingray/unit/material/material.go
+++ b/stingray/unit/material/material.go
@@ -553,7 +553,7 @@ func LoadGPU(r io.ReadSeeker) (*MaterialGPU, error) {
 					return nil, err
 				}
 			}
-			if block.Headers[i].StageMask&ShaderStage_InstancedVertex != 0 && block.Headers[i].Stages[0].DXBCSize > 0 {
+			if block.Headers[i].StageMask&ShaderStage_InstancedVertex != 0 && block.Headers[i].StageMask&ShaderStage_Vertex == 0 && block.Headers[i].Stages[0].DXBCSize > 0 {
 				stage := block.Headers[i].Stages[ShaderStage_InstancedVertex.StageIdx()]
 				if shader, ok := loadedShaders[stage.DXBCName]; ok {
 					block.Programs[i].InstancedVertexShader = shader


### PR DESCRIPTION
Zones in helldivers have "terrain lookup" units that contain ~24-32 planes with attached terrain materials. This change adds support for a custom shader for those terrain lookup materials. I'm planning to add another material in the near future that will mix those materials to apply to actual terrain when exporting terrain units

I think this PR has a conflict with the speedtree emissive shader PR, so once that's merged to master I'll rebase this branch on top of that