### PR TITLE
Fix panic when a unit has no material indices

### DIFF
--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -1265,8 +1265,9 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, me
 
 			var material *uint32
 			// There are a couple of models where there are fewer materials than meshes, so this is here
-			// to prevent us from panicking if we're exporting one of those
-			if int(group.MaterialIdx) < len(header.Materials) {
+			// to prevent us from panicking if we're exporting one of those (and some units, e.g.
+			// content/fac_illuminate/vehicles/illuminate_attack_ship, carry no material indices at all)
+			if len(materialIndices) > 0 && int(group.MaterialIdx) < len(header.Materials) {
 				materialVal, ok := materialIndices[0].MaterialHashToIndex[header.Materials[group.MaterialIdx]]
 				if ok {
 					material = &materialVal


### PR DESCRIPTION
Fixes #256.

Some units carry mesh groups but an empty `materialIndices` slice, so
`materialIndices[0]` panics in `LoadGLTF` with `index out of range [0] with length 0`
and aborts the extraction run. Known specimens (archive `046d4441a6dae0a9`, current
HD2 build):

- `content/fac_illuminate/vehicles/illuminate_attack_ship/illuminate_attack_ship.unit`
- `content/fac_illuminate/vehicles/illuminate_attack_ship_destroyed.unit`

The comment/guard just above the panic site already covers the
fewer-materials-than-meshes case; this change extends the same guard to the
no-material-indices case. Affected groups now export with no material assigned —
the same degrade path already taken when the material-hash lookup misses. Paths
where `materialIndices` is non-empty are untouched.

Tested on Linux against the current HD2 build at master + this change: both units
above extract cleanly (geometry + rig intact), where master panics.