### PR TITLE
Expand the bones used as LOD parents

### DIFF
--- a/extractor/geometry/extractor.go
+++ b/extractor/geometry/extractor.go
@@ -909,12 +909,16 @@ func LoadGLTF(ctx *extractor.Context, gpuR io.ReadSeeker, doc *gltf.Document, me
 	boneList := make([]int, 0)
 	gameMeshIdx := -1
 	for idx, bone := range unitInfo.Bones {
+		if len(bone.Children) == 0 {
+			continue
+		}
 		name := ctx.LookupThinHash(bone.NameHash)
-		switch name {
-		case "game_mesh":
+		if strings.Contains(name, "game") {
 			gameMeshIdx = idx
-			fallthrough
-		case "shadow_mesh", "rubble", "rubble_collision":
+		}
+		if strings.Contains(name, "game") ||
+			strings.Contains(name, "shadow") ||
+			strings.Contains(name, "rubble") {
 			boneList = append(boneList, idx)
 		}
 	}

--- a/patterns/unit.hexpat
+++ b/patterns/unit.hexpat
@@ -272,7 +272,7 @@ struct MeshInfo {
     AABB bounding_box;
     float unkFloat;
     u32 unkInt0;
-    ThinMurmurHash unkHash;
+    ThinMurmurHash name;
     u32 AABBTransformIndex;
     u32 TransformIndex;
     u32 unkInt2;


### PR DESCRIPTION
Some units have non-standard LOD parent bones, like sliced buildings with "game_slice_NN" or some corpse assets with "\<mesh-name>_game_mesh"

This change expands the matched bones to try to catch more of those cases