### PR TITLE
Add metadata to armor material for pattern/id mask layers

### DIFF
--- a/extractor/material/extractor.go
+++ b/extractor/material/extractor.go
@@ -402,7 +402,8 @@ func WriteDDS(ctx *extractor.Context, doc *gltf.Document, ddsR io.ReadSeeker, po
 		return 0, err
 	}
 
-	if len(tex.Images) > 1 {
+	layers := len(tex.Images)
+	if layers > 1 {
 		tex = dds.StackLayers(tex)
 	}
 
@@ -446,6 +447,9 @@ func WriteDDS(ctx *extractor.Context, doc *gltf.Document, ddsR io.ReadSeeker, po
 		Source:  gltf.Index(imgIdx),
 	})
 	texIdx := uint32(len(doc.Textures) - 1)
+	if layers > 1 {
+		doc.Textures[texIdx].Extras = map[string]any{"layers": []float32{float32(layers)}}
+	}
 	if imgOpts != nil && imgOpts.Raw {
 		if _, err := ddsR.Seek(0, io.SeekStart); err != nil {
 			ctx.Warnf("WriteTexture: dds reader failed to seek start")
@@ -1428,6 +1432,25 @@ func AddMaterial(ctx *extractor.Context, mat *material.Material, doc *gltf.Docum
 				continue
 			}
 			usedTextures[texUsageStr] = index
+			if (texUsageStr == "id_masks_array" || texUsageStr == "pattern_masks_array") && doc.Textures[index].Extras != nil {
+				extras, ok := doc.Textures[index].Extras.(map[string]any)
+				if !ok {
+					continue
+				}
+				layersAny, ok := extras["layers"]
+				if !ok {
+					continue
+				}
+				layers, ok := layersAny.([]float32)
+				if !ok {
+					continue
+				}
+				settingName := "fd_id_mask_layers"
+				if texUsageStr == "pattern_masks_array" {
+					settingName = "fd_pattern_mask_layers"
+				}
+				mat.Settings[stingray.Sum(settingName).Thin()] = layers
+			}
 		case "lens_cutout_texture":
 			fallthrough
 		case "scorch_marks":

--- a/hashes/thinhashes.txt
+++ b/hashes/thinhashes.txt
@@ -6514,6 +6514,8 @@ fan_m_03
 fan_m_04
 fan_r_bt
 fan_r_tp
+fd_id_mask_layers
+fd_pattern_mask_layers
 feed
 feed_arm
 feed_bolt

--- a/scripts/material_loaders/armor_material_loader.py
+++ b/scripts/material_loaders/armor_material_loader.py
@@ -38,7 +38,7 @@ class ArmorMaterialLoader(FilediverMaterialLoaderInterface):
         self.shader_module = shader_script.as_module()
         if "HD2 Shader" not in bpy.data.materials:
             with bpy.data.libraries.load(str(resource_path / "Helldivers2 Shader v1.0.5.blend")) as (shader_blend, our_blend):
-                our_blend: BlendData # not actually but they share member names 
+                our_blend: BlendData # not actually but they share member names
                 shader_blend: BlendData
                 our_blend.materials = shader_blend.materials
         self.material = bpy.data.materials["HD2 Shader"]
@@ -84,6 +84,10 @@ class ArmorMaterialLoader(FilediverMaterialLoaderInterface):
                     image.colorspace_settings.name = "Non-Color"
 
         for setting, value in config.get("extras", {}).items():
+            if type(value) == list and len(value) == 1:
+                object_mat[setting] = value[0]
+            else:
+                object_mat[setting] = value
             if setting not in config_nodes["HD2 Shader Template"].inputs:
                 continue
             if setting == "decal_id" and value == "unused":

--- a/scripts/resources/Helldivers2 shader script v1.0.6-1.py
+++ b/scripts/resources/Helldivers2 shader script v1.0.6-1.py
@@ -13039,7 +13039,7 @@ def update_array_uvs(material: Material):
     try:
         IDMaskArraySizeX = material.node_tree.nodes['ID Mask Array Texture'].inputs[0].node.image.size[0]
         IDMaskArraySizeY = material.node_tree.nodes['ID Mask Array Texture'].inputs[0].node.image.size[1]
-        if (IDMaskArraySizeY/IDMaskArraySizeX) >= 2.0:
+        if (IDMaskArraySizeY/IDMaskArraySizeX) >= 2.0 or (material.get("fd_id_mask_layers") is not None and material.get("fd_id_mask_layers") > 1):
             material.node_tree.nodes['ID Mask UV'].inputs[0].default_value = (1.000)
     except:
         pass
@@ -13047,7 +13047,7 @@ def update_array_uvs(material: Material):
     try:
         PatternMaskArraySizeX = material.node_tree.nodes['Pattern Mask Array'].inputs[0].node.image.size[0]
         PatternMaskArraySizeY = material.node_tree.nodes['Pattern Mask Array'].inputs[0].node.image.size[1]
-        if (PatternMaskArraySizeY/PatternMaskArraySizeX) >= 2.0:
+        if (PatternMaskArraySizeY/PatternMaskArraySizeX) >= 2.0 or (material.get("fd_pattern_mask_layers") is not None and material.get("fd_pattern_mask_layers") > 1):
             material.node_tree.nodes['Pattern Mask UV'].inputs[0].default_value = (1.000)
     except:
         pass


### PR DESCRIPTION
The shader currently guesses if an id/pattern mask has multiple layers based on its height. With this change I've added metadata that explicitly sets the number of layers each mask has, to avoid guessing