### PR TITLE
Export embedded prefabs contained within levels

### DIFF
--- a/cmd/filediver-cli/main.go
+++ b/cmd/filediver-cli/main.go
@@ -1253,7 +1253,7 @@ func handleLevelThinHashes(prt app.Printer, a *app.App, id stingray.FileID, optT
 			unknownHash[hashIndexRange.Hash.String()] = true
 		}
 	}
-	for _, hashIndexRange := range info.UnkHashIndexRange4 {
+	for _, hashIndexRange := range info.EmbeddedPrefabHashIndexRange {
 		if *optThinToFind != "" && stingray.Sum(*optThinToFind).Thin() == hashIndexRange.Hash {
 			shadingEnvironmentName, exists := a.Hashes[id.Name]
 			if !exists {

--- a/cmd/tools/filediver-dump-hashes-for-hash-cracker/find_thin_hashes.go
+++ b/cmd/tools/filediver-dump-hashes-for-hash-cracker/find_thin_hashes.go
@@ -215,7 +215,7 @@ func handleLevelThinHashes(prt app.Printer, a *app.App, id stingray.FileID, know
 			unknown[hashIndexRange.Hash.Value] = true
 		}
 	}
-	for _, hashIndexRange := range info.UnkHashIndexRange4 {
+	for _, hashIndexRange := range info.EmbeddedPrefabHashIndexRange {
 		if nameStr, exists := a.ThinHashes[hashIndexRange.Hash]; exists {
 			known[nameStr] = true
 		} else {

--- a/cmd/tools/level-object-name-dumper/main.go
+++ b/cmd/tools/level-object-name-dumper/main.go
@@ -50,7 +50,7 @@ func dumpLevelObjectNames(a *app.App, fileID stingray.FileID) error {
 			fmt.Println(unit.Name.String())
 		}
 	}
-	for _, extra := range levelData.UnkExtraUnitContainers {
+	for _, extra := range levelData.EmbeddedPrefabs {
 		// for _, prefab := range extra.ExtraPrefabs {
 		// 	knownName, ok := a.Hashes[prefab.UnkHash1]
 		// 	if ok {
@@ -59,7 +59,7 @@ func dumpLevelObjectNames(a *app.App, fileID stingray.FileID) error {
 		// 		fmt.Println(prefab.UnkHash1.String())
 		// 	}
 		// }
-		for _, unit := range extra.ExtraUnits {
+		for _, unit := range extra.Units {
 			// knownName, ok := a.Hashes[unit.UUIDHash]
 			// if ok {
 			// 	fmt.Println(knownName)
@@ -71,6 +71,15 @@ func dumpLevelObjectNames(a *app.App, fileID stingray.FileID) error {
 				fmt.Println(knownName)
 			} else {
 				fmt.Println(unit.Name.String())
+			}
+		}
+
+		for _, prefab := range extra.NestedPrefabs {
+			knownName, ok := a.Hashes[prefab.Name]
+			if ok {
+				fmt.Println(knownName)
+			} else {
+				fmt.Println(prefab.Name.String())
 			}
 		}
 	}

--- a/extractor/level/extractor.go
+++ b/extractor/level/extractor.go
@@ -275,9 +275,9 @@ func ExtractLevelJSON(ctx *extractor.Context) error {
 		}
 	}
 
-	if levelData.UnkHashIndexRange4 != nil {
+	if levelData.EmbeddedPrefabHashIndexRange != nil {
 		outData.EmbeddedPrefabHashIndexRange = make([]SimpleHashIndexRange, 0)
-		for _, hashIndexRange := range levelData.UnkHashIndexRange4 {
+		for _, hashIndexRange := range levelData.EmbeddedPrefabHashIndexRange {
 			outData.EmbeddedPrefabHashIndexRange = append(outData.EmbeddedPrefabHashIndexRange, SimpleHashIndexRange{
 				Hash:  ctx.LookupThinHash(hashIndexRange.Hash),
 				Start: hashIndexRange.Start,

--- a/extractor/level/extractor.go
+++ b/extractor/level/extractor.go
@@ -85,12 +85,12 @@ type SimpleEmbeddedPrefab struct {
 type SimpleLevel struct {
 	Name                         string                   `json:"name"`
 	Metadata                     map[int][]SimpleMetadata `json:"metadata"`
-	Prefabs                      []SimplePrefab           `json:"prefabs"`
 	MaterialOverrides            []SimpleMaterialOverride `json:"material_overrides"`
 	Units                        []SimpleUnit             `json:"units"`
+	Prefabs                      []SimplePrefab           `json:"prefabs"`
+	EmbeddedPrefabs              []SimpleEmbeddedPrefab   `json:"embedded_prefabs"`
 	Speedtrees                   []SimpleSpeedtree        `json:"speedtrees"`
 	Entity                       *entity.SimpleEntity     `json:"entity"`
-	EmbeddedPrefabs              []SimpleEmbeddedPrefab   `json:"embedded_prefabs"`
 	UnitHashIndexRange           []SimpleHashIndexRange   `json:"unit_hash_index_range"`
 	UnkHashIndexRange1           []SimpleHashIndexRange   `json:"unk_hash_index_range_1"`
 	UnkHashIndexRange2           []SimpleHashIndexRange   `json:"unk_hash_index_range_2"`
@@ -358,7 +358,7 @@ func ConvertOpts(ctx *extractor.Context, gltfDoc *gltf.Document) error {
 	}
 	doc.Extras = extras
 
-	totalObjectCount := float32(len(levelData.Units) + len(levelData.Prefabs) + len(levelData.Speedtrees))
+	totalObjectCount := float32(len(levelData.Units) + len(levelData.EmbeddedPrefabs) + len(levelData.Prefabs) + len(levelData.Speedtrees))
 	for idx, prefab := range levelData.Prefabs {
 		if ctxErr := ctx.Ctx().Err(); errors.Is(ctxErr, context.Canceled) {
 			return ctxErr
@@ -396,6 +396,50 @@ func ConvertOpts(ctx *extractor.Context, gltfDoc *gltf.Document) error {
 		}
 
 		position, rotation, scale := prefab.ToGLTF()
+		doc.Nodes[node].Translation = position
+		doc.Nodes[node].Rotation = rotation
+		doc.Nodes[node].Scale = scale
+
+		doc.Nodes[levelIdx].Children = append(doc.Nodes[levelIdx].Children, node)
+	}
+
+	for idx, embedded := range levelData.EmbeddedPrefabs {
+		if ctxErr := ctx.Ctx().Err(); errors.Is(ctxErr, context.Canceled) {
+			return ctxErr
+		}
+		if ctx.FileID() == ctx.RootFileID() {
+			percentComplete := 100 * float32(idx+1) / totalObjectCount
+			ctx.Statusf("%.2f%% - %v.prefab (embedded)", percentComplete, ctx.LookupHash(embedded.EmbeddedPrefabTransform.Hash))
+		}
+		prefabId := ctx.OverrideAsset(stingray.NewFileID(embedded.EmbeddedPrefabTransform.Hash, stingray.Sum("prefab")))
+		node, err := extr_prefab.AddPrefabData(ctx.WithFileID(prefabId), doc, imgOpts, &embedded.Prefab)
+		if err != nil {
+			return err
+		}
+		extras, ok := doc.Extras.(map[string]any)
+		if !ok {
+			return fmt.Errorf("prefab export did not add extras? (should not happen)")
+		}
+		prefabMetadataIface, contains := extras[extr_prefab.GetPrefabExtrasID(prefabId)]
+		if !contains {
+			return fmt.Errorf("prefab export did not add metadata? (should not happen)")
+		}
+		prefabMetadata, ok := prefabMetadataIface.(map[string]any)
+		if !ok {
+			return fmt.Errorf("prefab metadata could not be converted? (should not happen)")
+		}
+		parentIface, contains := prefabMetadata["parent"]
+		if !contains {
+			return fmt.Errorf("prefab parent was not added? (should not happen)")
+		}
+		if _, ok := parentIface.(uint32); !ok {
+			// parent was nil
+			prefabMetadata["parent"] = levelIdx
+			extras[extr_prefab.GetPrefabExtrasID(prefabId)] = prefabMetadata
+			doc.Extras = extras
+		}
+
+		position, rotation, scale := embedded.ToGLTF()
 		doc.Nodes[node].Translation = position
 		doc.Nodes[node].Rotation = rotation
 		doc.Nodes[node].Scale = scale

--- a/extractor/level/extractor.go
+++ b/extractor/level/extractor.go
@@ -65,39 +65,10 @@ type SimpleSpeedtree struct {
 	SpeedtreeTransforms []SimpleSpeedtreeTransform `json:"transforms"`
 }
 
-type SimpleUnknownTransformedItem struct {
+type SimpleEmbeddedPrefabTransform struct {
 	Hash string `json:"hash"`
 	stingray.Transform
 	UnkFloats [6]float32 `json:"unk_floats"`
-}
-
-type SimpleExtraUnit struct {
-	UUID string `json:"uuid"`
-	Path string `json:"path"`
-	Name string `json:"name"`
-	stingray.Transform
-	UnkFloats [3]float32 `json:"unk_floats"`
-	UnkInt    uint32     `json:"unk_int"`
-	UnkInt2   uint32     `json:"unk_int_2"`
-}
-
-type SimpleExtraPrefab struct {
-	UUID string `json:"uuid"`
-	Path string `json:"path"`
-	stingray.Transform
-	UnkFloats [3]float32 `json:"unk_floats"`
-	UnkInt    uint32     `json:"unk_int"`
-}
-
-type SimpleExtraUnitsContainer struct {
-	UnkInt              uint32               `json:"unk_int"`
-	UnkInt2             uint32               `json:"unk_int_2"`
-	LevelName           string               `json:"level_name"`
-	ExtraUnits          []SimpleExtraUnit    `json:"extra_units"`
-	ExtraPrefabs        []SimpleExtraPrefab  `json:"extra_prefabs"`
-	UnkIntList          []uint32             `json:"unk_int_list"`
-	UnkFloatTwoIntsList []level.FloatTwoInts `json:"unk_float_two_ints_list"`
-	UnkIntsAndFloatList []level.IntsAndFloat `json:"unk_ints_and_float"`
 }
 
 type SimpleHashIndexRange struct {
@@ -106,23 +77,27 @@ type SimpleHashIndexRange struct {
 	End   uint32 `json:"end"`
 }
 
+type SimpleEmbeddedPrefab struct {
+	Transform SimpleEmbeddedPrefabTransform `json:"header"`
+	Prefab    extr_prefab.SimplePrefab      `json:"prefab"`
+}
+
 type SimpleLevel struct {
-	Name                 string                         `json:"name"`
-	Metadata             map[int][]SimpleMetadata       `json:"metadata"`
-	Prefabs              []SimplePrefab                 `json:"prefabs"`
-	MaterialOverrides    []SimpleMaterialOverride       `json:"material_overrides"`
-	Units                []SimpleUnit                   `json:"units"`
-	Speedtrees           []SimpleSpeedtree              `json:"speedtrees"`
-	Entity               *entity.SimpleEntity           `json:"entity"`
-	UnkTransformedItems  []SimpleUnknownTransformedItem `json:"unk_transformed_item"`
-	UnkExtraUnits        []SimpleExtraUnitsContainer    `json:"unk_extra_units"`
-	UnitHashIndexRange   []SimpleHashIndexRange         `json:"unit_hash_index_range"`
-	UnkHashIndexRange1   []SimpleHashIndexRange         `json:"unk_hash_index_range_1"`
-	UnkHashIndexRange2   []SimpleHashIndexRange         `json:"unk_hash_index_range_2"`
-	UnkHashIndexRange3   []SimpleHashIndexRange         `json:"unk_hash_index_range_3"`
-	PrefabHashIndexRange []SimpleHashIndexRange         `json:"prefab_hash_index_range"`
-	UnkHashIndexRange4   []SimpleHashIndexRange         `json:"unk_hash_index_range_4"`
-	UnkHashIndexRange5   []SimpleHashIndexRange         `json:"unk_hash_index_range_5"`
+	Name                         string                   `json:"name"`
+	Metadata                     map[int][]SimpleMetadata `json:"metadata"`
+	Prefabs                      []SimplePrefab           `json:"prefabs"`
+	MaterialOverrides            []SimpleMaterialOverride `json:"material_overrides"`
+	Units                        []SimpleUnit             `json:"units"`
+	Speedtrees                   []SimpleSpeedtree        `json:"speedtrees"`
+	Entity                       *entity.SimpleEntity     `json:"entity"`
+	EmbeddedPrefabs              []SimpleEmbeddedPrefab   `json:"embedded_prefabs"`
+	UnitHashIndexRange           []SimpleHashIndexRange   `json:"unit_hash_index_range"`
+	UnkHashIndexRange1           []SimpleHashIndexRange   `json:"unk_hash_index_range_1"`
+	UnkHashIndexRange2           []SimpleHashIndexRange   `json:"unk_hash_index_range_2"`
+	UnkHashIndexRange3           []SimpleHashIndexRange   `json:"unk_hash_index_range_3"`
+	PrefabHashIndexRange         []SimpleHashIndexRange   `json:"prefab_hash_index_range"`
+	EmbeddedPrefabHashIndexRange []SimpleHashIndexRange   `json:"embedded_prefab_hash_index_range"`
+	UnkHashIndexRange5           []SimpleHashIndexRange   `json:"unk_hash_index_range_5"`
 }
 
 func ExtractLevelJSON(ctx *extractor.Context) error {
@@ -222,6 +197,18 @@ func ExtractLevelJSON(ctx *extractor.Context) error {
 		simpleEntity.FromEntity(ctx, levelData.Entity)
 	}
 
+	embeddedPrefabs := make([]SimpleEmbeddedPrefab, 0)
+	for _, item := range levelData.EmbeddedPrefabs {
+		embeddedPrefabs = append(embeddedPrefabs, SimpleEmbeddedPrefab{
+			Transform: SimpleEmbeddedPrefabTransform{
+				Hash:      ctx.LookupHash(item.Hash),
+				Transform: item.Transform,
+				UnkFloats: item.UnkFloats,
+			},
+			Prefab: extr_prefab.ToSimple(ctx, item.Prefab),
+		})
+	}
+
 	outData := SimpleLevel{
 		Name:              ctx.LookupHash(levelData.Name),
 		Metadata:          metadata,
@@ -230,51 +217,7 @@ func ExtractLevelJSON(ctx *extractor.Context) error {
 		Units:             units,
 		Speedtrees:        speedtrees,
 		Entity:            simpleEntity,
-	}
-
-	outData.UnkTransformedItems = make([]SimpleUnknownTransformedItem, 0)
-	for _, item := range levelData.UnkTransformedItems {
-		outData.UnkTransformedItems = append(outData.UnkTransformedItems, SimpleUnknownTransformedItem{
-			Hash:      ctx.LookupHash(item.Hash),
-			Transform: item.Transform,
-			UnkFloats: item.UnkFloats,
-		})
-	}
-
-	outData.UnkExtraUnits = make([]SimpleExtraUnitsContainer, 0)
-	for _, container := range levelData.UnkExtraUnitContainers {
-		extraUnits := make([]SimpleExtraUnit, 0)
-		for _, unit := range container.ExtraUnits {
-			extraUnits = append(extraUnits, SimpleExtraUnit{
-				UUID:      ctx.LookupHash(unit.UUIDHash),
-				Path:      ctx.LookupHash(unit.Path),
-				Name:      ctx.LookupHash(unit.Name),
-				Transform: unit.Transform,
-				UnkFloats: unit.UnkFloats,
-				UnkInt:    unit.UnkInt,
-				UnkInt2:   unit.UnkInt2,
-			})
-		}
-		extraPrefabs := make([]SimpleExtraPrefab, 0)
-		for _, prefab := range container.ExtraPrefabs {
-			extraPrefabs = append(extraPrefabs, SimpleExtraPrefab{
-				UUID:      ctx.LookupHash(prefab.UUIDHash),
-				Path:      ctx.LookupHash(prefab.Path),
-				Transform: prefab.Transform,
-				UnkFloats: prefab.UnkFloats,
-				UnkInt:    prefab.UnkInt,
-			})
-		}
-		outData.UnkExtraUnits = append(outData.UnkExtraUnits, SimpleExtraUnitsContainer{
-			UnkInt:              container.UnkInt,
-			UnkInt2:             container.UnkInt2,
-			LevelName:           ctx.LookupHash(container.LevelName),
-			ExtraUnits:          extraUnits,
-			ExtraPrefabs:        extraPrefabs,
-			UnkIntList:          container.UnkIntList,
-			UnkFloatTwoIntsList: container.UnkFloatTwoIntsList,
-			UnkIntsAndFloatList: container.UnkIntsAndFloatList,
-		})
+		EmbeddedPrefabs:   embeddedPrefabs,
 	}
 
 	if levelData.UnitHashIndexRange != nil {
@@ -333,9 +276,9 @@ func ExtractLevelJSON(ctx *extractor.Context) error {
 	}
 
 	if levelData.UnkHashIndexRange4 != nil {
-		outData.UnkHashIndexRange4 = make([]SimpleHashIndexRange, 0)
+		outData.EmbeddedPrefabHashIndexRange = make([]SimpleHashIndexRange, 0)
 		for _, hashIndexRange := range levelData.UnkHashIndexRange4 {
-			outData.UnkHashIndexRange4 = append(outData.UnkHashIndexRange4, SimpleHashIndexRange{
+			outData.EmbeddedPrefabHashIndexRange = append(outData.EmbeddedPrefabHashIndexRange, SimpleHashIndexRange{
 				Hash:  ctx.LookupThinHash(hashIndexRange.Hash),
 				Start: hashIndexRange.Start,
 				End:   hashIndexRange.End,

--- a/extractor/prefab/extractor.go
+++ b/extractor/prefab/extractor.go
@@ -23,19 +23,20 @@ type SimpleHeader struct {
 }
 
 type SimpleUnit struct {
-	UnkHash0 string `json:"unk_hash_0"`
+	UUID     string `json:"uuid"`
 	Path     string `json:"path"`
-	UnkHash1 string `json:"unk_hash_1"`
+	Name     string `json:"name"`
 	UnkHash2 string `json:"unk_hash_2"`
 	stingray.Transform
-	UnkRotation mgl32.Vec4 `json:"unk_rotation"`
-	Index       uint32     `json:"index"`
+	UnkVec mgl32.Vec3 `json:"unk_vec"`
+	UnkInt uint32     `json:"unk_int"`
+	Index  uint32     `json:"index"`
 }
 
 type SimpleNestedPrefab struct {
-	UnkInt  uint32 `json:"unk_int"`
-	UnkHash string `json:"unk_hash"`
-	Path    string `json:"path"`
+	UnkInt uint32 `json:"unk_int"`
+	Name   string `json:"name"`
+	Path   string `json:"path"`
 	stingray.Transform
 	UnkFloats mgl32.Vec3 `json:"unk_floats"`
 }
@@ -44,6 +45,38 @@ type SimplePrefab struct {
 	Name    string               `json:"name"`
 	Units   []SimpleUnit         `json:"units"`
 	Prefabs []SimpleNestedPrefab `json:"prefabs"`
+}
+
+func ToSimple(ctx *extractor.Context, prefabData prefab.Prefab) SimplePrefab {
+	units := make([]SimpleUnit, 0)
+	for _, unit := range prefabData.Units {
+		units = append(units, SimpleUnit{
+			UUID:      ctx.LookupHash(unit.UUID),
+			Path:      ctx.LookupHash(unit.Path()),
+			Name:      ctx.LookupHash(unit.Name),
+			UnkHash2:  ctx.LookupHash(stingray.Hash{Value: unit.Unk02}),
+			Transform: unit.Transform,
+			UnkVec:    unit.UnkVec,
+			UnkInt:    unit.UnkInt,
+			Index:     unit.Index,
+		})
+	}
+	prefabs := make([]SimpleNestedPrefab, 0)
+	for _, prefab := range prefabData.NestedPrefabs {
+		prefabs = append(prefabs, SimpleNestedPrefab{
+			UnkInt:    prefab.UnkInt,
+			Name:      ctx.LookupHash(prefab.Name),
+			Path:      ctx.LookupHash(prefab.Path),
+			Transform: prefab.Transform,
+			UnkFloats: prefab.UnkFloats,
+		})
+	}
+	result := SimplePrefab{
+		Name:    ctx.LookupHash(prefabData.NameHash),
+		Prefabs: prefabs,
+		Units:   units,
+	}
+	return result
 }
 
 func ExtractPrefabJSON(ctx *extractor.Context) error {
@@ -55,33 +88,8 @@ func ExtractPrefabJSON(ctx *extractor.Context) error {
 	if err != nil {
 		return err
 	}
-	units := make([]SimpleUnit, 0)
-	for _, unit := range prefabData.Units {
-		units = append(units, SimpleUnit{
-			UnkHash0:    ctx.LookupHash(stingray.Hash{Value: unit.Unk00}),
-			Path:        ctx.LookupHash(unit.Path()),
-			UnkHash1:    ctx.LookupHash(stingray.Hash{Value: unit.Unk01}),
-			UnkHash2:    ctx.LookupHash(stingray.Hash{Value: unit.Unk02}),
-			Transform:   unit.Transform,
-			UnkRotation: unit.UnkFloats,
-			Index:       unit.Index,
-		})
-	}
-	prefabs := make([]SimpleNestedPrefab, 0)
-	for _, prefab := range prefabData.NestedPrefabs {
-		prefabs = append(prefabs, SimpleNestedPrefab{
-			UnkInt:    prefab.UnkInt,
-			UnkHash:   ctx.LookupHash(prefab.UnkHash),
-			Path:      ctx.LookupHash(prefab.Path),
-			Transform: prefab.Transform,
-			UnkFloats: prefab.UnkFloats,
-		})
-	}
-	outData := SimplePrefab{
-		Name:    ctx.LookupHash(prefabData.NameHash),
-		Prefabs: prefabs,
-		Units:   units,
-	}
+
+	outData := ToSimple(ctx, *prefabData)
 
 	out, err := ctx.CreateFile(".prefab.json")
 	if err != nil {

--- a/extractor/prefab/extractor.go
+++ b/extractor/prefab/extractor.go
@@ -304,6 +304,10 @@ func AddPrefab(ctx *extractor.Context, doc *gltf.Document, imgOpts *extr_materia
 		return 0, err
 	}
 
+	return AddPrefabData(ctx, doc, imgOpts, prefabData)
+}
+
+func AddPrefabData(ctx *extractor.Context, doc *gltf.Document, imgOpts *extr_material.ImageOptions, prefabData *prefab.Prefab) (uint32, error) {
 	extras, ok := doc.Extras.(map[string]any)
 	if !ok {
 		extras = make(map[string]any)

--- a/stingray/level/level.go
+++ b/stingray/level/level.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/xypwn/filediver/stingray"
 	"github.com/xypwn/filediver/stingray/entity"
+	"github.com/xypwn/filediver/stingray/prefab"
 	"github.com/xypwn/filediver/stingray/shading_environment"
 )
 
@@ -192,10 +193,15 @@ type HashIndexRange struct {
 	End   uint32 // Exclusive
 }
 
-type UnknownTransformedItem struct {
+type EmbeddedPrefabTransform struct {
 	Hash stingray.Hash
 	stingray.Transform
 	UnkFloats [6]float32
+}
+
+type EmbeddedPrefab struct {
+	EmbeddedPrefabTransform
+	prefab.Prefab
 }
 
 type ExtraUnit struct {
@@ -217,44 +223,6 @@ type ExtraPrefab struct {
 	UnkInt    uint32
 }
 
-type FloatTwoInts struct {
-	UnkFloat float32 `json:"unk_float"`
-	UnkInt1  uint32  `json:"unk_int_1"`
-	UnkInt2  uint32  `json:"unk_int_2"`
-}
-
-type IntsAndFloat struct {
-	UnkInts  [14]uint32 `json:"unk_ints"`
-	UnkFloat float32    `json:"unk_float"`
-}
-
-type rawExtraUnitHeader struct {
-	UnkInt                    uint32
-	UnkInt2                   uint32
-	LevelName                 stingray.Hash
-	ExtraUnitsPtrListOffset   uint32 // Relative to this container
-	UnkOffset1                uint32
-	ExtraPrefabsPtrListOffset uint32
-	UnkOffset3                uint32
-	UnkIntListOffset          uint32
-	UnkFloatTwoIntsListOffset uint32
-	UnkIntsAndFloatListOffset uint32
-	UnkOffset4                uint32
-	UnkOffset5                uint32
-	UnkOffset6                uint32
-}
-
-type ExtraUnitsContainer struct {
-	UnkInt              uint32
-	UnkInt2             uint32
-	LevelName           stingray.Hash
-	ExtraUnits          []ExtraUnit
-	ExtraPrefabs        []ExtraPrefab
-	UnkIntList          []uint32
-	UnkFloatTwoIntsList []FloatTwoInts
-	UnkIntsAndFloatList []IntsAndFloat
-}
-
 type RawLevel struct {
 	Magic                          uint32
 	UnitCount                      uint32
@@ -266,10 +234,10 @@ type RawLevel struct {
 	UnkOffsets02                   [8]uint32
 	PrefabCount                    uint32
 	PrefabOffset                   uint32
-	UnkHashCount                   uint32
-	UnkHashesOffset                uint32
-	UnkTransformedItemOffsetOffset uint32 // Double pointers for several items here
-	ExtraUnitsInfoOffset           uint32
+	EmbeddedPrefabsCount           uint32
+	EmbeddedPrefabHashesOffset     uint32
+	EmbeddedPrefabTransformsOffset uint32 // Double pointers for several items here
+	EmbeddedPrefabsOffset          uint32
 	UnitHashIndexRangeOffset       uint32
 	UnkHashIndexRangeOffset0       uint32
 	UnkHashIndexRangeOffset1       uint32
@@ -291,141 +259,21 @@ type RawLevel struct {
 }
 
 type Level struct {
-	Name                   stingray.Hash
-	Metadata               map[int][]MetadataEntry
-	Prefabs                []Prefab
-	MaterialOverrides      map[int]map[stingray.ThinHash]stingray.Hash
-	Units                  []Unit
-	Speedtrees             []Speedtree
-	Entity                 *entity.Entity
-	UnkTransformedItems    []UnknownTransformedItem
-	UnkExtraUnitContainers []ExtraUnitsContainer
-	UnitHashIndexRange     []HashIndexRange
-	UnkHashIndexRange1     []HashIndexRange
-	UnkHashIndexRange2     []HashIndexRange
-	UnkHashIndexRange3     []HashIndexRange
-	PrefabHashIndexRange   []HashIndexRange
-	UnkHashIndexRange4     []HashIndexRange
-	UnkHashIndexRange5     []HashIndexRange
-}
-
-func readExtraUnitsContainer(r io.ReadSeeker, extraUnitsHeaderOffset uint32) (*ExtraUnitsContainer, error) {
-	extraUnitsContainer := &ExtraUnitsContainer{}
-	var extraUnitsHeader rawExtraUnitHeader
-	if err := binary.Read(r, binary.LittleEndian, &extraUnitsHeader); err != nil {
-		return nil, err
-	}
-	extraUnitsContainer.UnkInt = extraUnitsHeader.UnkInt
-	extraUnitsContainer.UnkInt2 = extraUnitsHeader.UnkInt2
-	extraUnitsContainer.LevelName = extraUnitsHeader.LevelName
-	if extraUnitsHeader.ExtraUnitsPtrListOffset != 0 {
-		extraUnitsContainer.ExtraUnits = make([]ExtraUnit, 0)
-		if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.ExtraUnitsPtrListOffset), io.SeekStart); err != nil {
-			return nil, err
-		}
-		var extraUnitsOffsetsCount uint32
-		if err := binary.Read(r, binary.LittleEndian, &extraUnitsOffsetsCount); err != nil {
-			return nil, err
-		}
-		if extraUnitsOffsetsCount > 512 {
-			return nil, fmt.Errorf("extraUnitsOffsetsCount too big: %v", extraUnitsOffsetsCount)
-		}
-		extraUnitsOffsets := make([]uint32, extraUnitsOffsetsCount)
-		if err := binary.Read(r, binary.LittleEndian, extraUnitsOffsets); err != nil {
-			return nil, err
-		}
-		for _, offset := range extraUnitsOffsets {
-			if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.ExtraUnitsPtrListOffset+offset), io.SeekStart); err != nil {
-				return nil, err
-			}
-			var unit ExtraUnit
-			if err := binary.Read(r, binary.LittleEndian, &unit); err != nil {
-				return nil, err
-			}
-			extraUnitsContainer.ExtraUnits = append(extraUnitsContainer.ExtraUnits, unit)
-		}
-	}
-
-	if extraUnitsHeader.ExtraPrefabsPtrListOffset != 0 {
-		if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.ExtraPrefabsPtrListOffset), io.SeekStart); err != nil {
-			return nil, err
-		}
-		var extraPrefabsCount uint32
-		if err := binary.Read(r, binary.LittleEndian, &extraPrefabsCount); err != nil {
-			return nil, err
-		}
-		var extraPrefabsOffset uint32
-		if err := binary.Read(r, binary.LittleEndian, &extraPrefabsOffset); err != nil {
-			return nil, fmt.Errorf("reading extraPrefabsOffsets: %v", err)
-		}
-		if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.ExtraPrefabsPtrListOffset+extraPrefabsOffset), io.SeekStart); err != nil {
-			return nil, fmt.Errorf("seeking extra prefab: %v", err)
-		}
-		extraUnitsContainer.ExtraPrefabs = make([]ExtraPrefab, 0)
-		if err := binary.Read(r, binary.LittleEndian, extraUnitsContainer.ExtraPrefabs); err != nil {
-			return nil, fmt.Errorf("reading extra prefab: %v", err)
-		}
-	}
-
-	if extraUnitsHeader.UnkIntListOffset != 0 {
-		if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.UnkIntListOffset), io.SeekStart); err != nil {
-			return nil, err
-		}
-		var unkIntListCount uint32
-		if err := binary.Read(r, binary.LittleEndian, &unkIntListCount); err != nil {
-			return nil, err
-		}
-		extraUnitsContainer.UnkIntList = make([]uint32, unkIntListCount)
-		if err := binary.Read(r, binary.LittleEndian, extraUnitsContainer.UnkIntList); err != nil {
-			return nil, err
-		}
-	}
-
-	if extraUnitsHeader.UnkFloatTwoIntsListOffset != 0 {
-		if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.UnkFloatTwoIntsListOffset), io.SeekStart); err != nil {
-			return nil, err
-		}
-		var unkFloatTwoIntsListCount, unkFloatTwoIntsListOffset uint32
-		if err := binary.Read(r, binary.LittleEndian, &unkFloatTwoIntsListCount); err != nil {
-			return nil, err
-		}
-		if err := binary.Read(r, binary.LittleEndian, &unkFloatTwoIntsListOffset); err != nil {
-			return nil, err
-		}
-
-		if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.UnkFloatTwoIntsListOffset+unkFloatTwoIntsListOffset), io.SeekStart); err != nil {
-			return nil, err
-		}
-		extraUnitsContainer.UnkFloatTwoIntsList = make([]FloatTwoInts, unkFloatTwoIntsListCount)
-		if err := binary.Read(r, binary.LittleEndian, extraUnitsContainer.UnkFloatTwoIntsList); err != nil {
-			return nil, err
-		}
-	}
-
-	if extraUnitsHeader.UnkIntsAndFloatListOffset != 0 {
-		if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.UnkIntsAndFloatListOffset), io.SeekStart); err != nil {
-			return nil, err
-		}
-		var unkIntsAndFloatListCount, unkIntsAndFloatListOffset uint32
-		if err := binary.Read(r, binary.LittleEndian, &unkIntsAndFloatListCount); err != nil {
-			return nil, err
-		}
-		if err := binary.Read(r, binary.LittleEndian, &unkIntsAndFloatListOffset); err != nil {
-			return nil, err
-		}
-		if _, err := r.Seek(int64(extraUnitsHeaderOffset+extraUnitsHeader.UnkIntsAndFloatListOffset+unkIntsAndFloatListOffset), io.SeekStart); err != nil {
-			return nil, err
-		}
-		if unkIntsAndFloatListCount > 512 {
-			return nil, fmt.Errorf("unkIntsAndFloatListCount too big: %v", unkIntsAndFloatListCount)
-		}
-		extraUnitsContainer.UnkIntsAndFloatList = make([]IntsAndFloat, unkIntsAndFloatListCount)
-		if err := binary.Read(r, binary.LittleEndian, extraUnitsContainer.UnkIntsAndFloatList); err != nil {
-			return nil, err
-		}
-	}
-
-	return extraUnitsContainer, nil
+	Name                 stingray.Hash
+	Metadata             map[int][]MetadataEntry
+	Prefabs              []Prefab
+	MaterialOverrides    map[int]map[stingray.ThinHash]stingray.Hash
+	Units                []Unit
+	Speedtrees           []Speedtree
+	Entity               *entity.Entity
+	EmbeddedPrefabs      []EmbeddedPrefab
+	UnitHashIndexRange   []HashIndexRange
+	UnkHashIndexRange1   []HashIndexRange
+	UnkHashIndexRange2   []HashIndexRange
+	UnkHashIndexRange3   []HashIndexRange
+	PrefabHashIndexRange []HashIndexRange
+	UnkHashIndexRange4   []HashIndexRange
+	UnkHashIndexRange5   []HashIndexRange
 }
 
 func LoadLevel(r io.ReadSeeker, entityVarMapping shading_environment.ShadingEnvironmentEntityToShaderMapping) (*Level, error) {
@@ -559,57 +407,57 @@ func LoadLevel(r io.ReadSeeker, entityVarMapping shading_environment.ShadingEnvi
 		}
 	}
 
-	unkTransformedItems := make([]UnknownTransformedItem, 0)
-	if raw.UnkTransformedItemOffsetOffset != 0 {
-		if _, err := r.Seek(int64(raw.UnkTransformedItemOffsetOffset), io.SeekStart); err != nil {
+	embeddedPrefabTransforms := make([]EmbeddedPrefabTransform, 0)
+	if raw.EmbeddedPrefabTransformsOffset != 0 {
+		if _, err := r.Seek(int64(raw.EmbeddedPrefabTransformsOffset), io.SeekStart); err != nil {
 			return nil, err
 		}
-		unkTransformedItemOffsets := make([]uint32, raw.UnkHashCount)
-		if err := binary.Read(r, binary.LittleEndian, unkTransformedItemOffsets); err != nil {
+		embeddedPrefabOffsets := make([]uint32, raw.EmbeddedPrefabsCount)
+		if err := binary.Read(r, binary.LittleEndian, embeddedPrefabOffsets); err != nil {
 			return nil, err
 		}
-		for _, offset := range unkTransformedItemOffsets {
+		for _, offset := range embeddedPrefabOffsets {
 			if offset == 0 {
 				continue
 			}
 			if _, err := r.Seek(int64(offset), io.SeekStart); err != nil {
 				return nil, err
 			}
-			unkTransformedItem := UnknownTransformedItem{}
-			if err := binary.Read(r, binary.LittleEndian, &unkTransformedItem); err != nil {
+			prefabTransform := EmbeddedPrefabTransform{}
+			if err := binary.Read(r, binary.LittleEndian, &prefabTransform); err != nil {
 				return nil, err
 			}
-			unkTransformedItems = append(unkTransformedItems, unkTransformedItem)
+			embeddedPrefabTransforms = append(embeddedPrefabTransforms, prefabTransform)
 		}
 	}
 
-	extraUnitsContainers := make([]ExtraUnitsContainer, 0)
-	if raw.ExtraUnitsInfoOffset != 0 {
-		if _, err := r.Seek(int64(raw.ExtraUnitsInfoOffset), io.SeekStart); err != nil {
+	embeddedPrefabs := make([]prefab.Prefab, 0)
+	if raw.EmbeddedPrefabsOffset != 0 {
+		if _, err := r.Seek(int64(raw.EmbeddedPrefabsOffset), io.SeekStart); err != nil {
 			return nil, err
 		}
-		containerInfos := make([]struct {
+		pairs := make([]struct {
 			Offset uint32
 			Size   uint32
-		}, raw.UnkHashCount)
+		}, raw.EmbeddedPrefabsCount)
 
-		if err := binary.Read(r, binary.LittleEndian, containerInfos); err != nil {
+		if err := binary.Read(r, binary.LittleEndian, pairs); err != nil {
 			return nil, err
 		}
 
-		for _, containerInfo := range containerInfos {
+		for _, containerInfo := range pairs {
 			if containerInfo.Offset == 0 || containerInfo.Size == 0 {
 				continue
 			}
 			if _, err := r.Seek(int64(containerInfo.Offset), io.SeekStart); err != nil {
 				return nil, err
 			}
-			extraUnitContainer, err := readExtraUnitsContainer(r, containerInfo.Offset)
+			embeddedPrefab, err := prefab.Load(r)
 			if err != nil {
 				return nil, err
 			}
-			if extraUnitContainer != nil {
-				extraUnitsContainers = append(extraUnitsContainers, *extraUnitContainer)
+			if embeddedPrefab != nil {
+				embeddedPrefabs = append(embeddedPrefabs, *embeddedPrefab)
 			}
 		}
 	}
@@ -670,22 +518,29 @@ func LoadLevel(r io.ReadSeeker, entityVarMapping shading_environment.ShadingEnvi
 		return nil, err
 	}
 
+	embeddedPrefabList := make([]EmbeddedPrefab, 0)
+	for i := range raw.EmbeddedPrefabsCount {
+		embeddedPrefabList = append(embeddedPrefabList, EmbeddedPrefab{
+			EmbeddedPrefabTransform: embeddedPrefabTransforms[i],
+			Prefab:                  embeddedPrefabs[i],
+		})
+	}
+
 	return &Level{
-		Name:                   raw.Name,
-		Metadata:               metadata,
-		Prefabs:                prefabs,
-		MaterialOverrides:      materialOverrides,
-		Units:                  units,
-		Speedtrees:             speedtrees,
-		Entity:                 embeddedEntity,
-		UnkTransformedItems:    unkTransformedItems,
-		UnkExtraUnitContainers: extraUnitsContainers,
-		UnitHashIndexRange:     unitHashIndexRangeList,
-		UnkHashIndexRange1:     unkHashIndexRangeList0,
-		UnkHashIndexRange2:     unkHashIndexRangeList1,
-		UnkHashIndexRange3:     unkHashIndexRangeList2,
-		PrefabHashIndexRange:   prefabHashIndexRangeList,
-		UnkHashIndexRange4:     unkHashIndexRangeList3,
-		UnkHashIndexRange5:     unkHashIndexRangeList4,
+		Name:                 raw.Name,
+		Metadata:             metadata,
+		Prefabs:              prefabs,
+		MaterialOverrides:    materialOverrides,
+		Units:                units,
+		Speedtrees:           speedtrees,
+		Entity:               embeddedEntity,
+		EmbeddedPrefabs:      embeddedPrefabList,
+		UnitHashIndexRange:   unitHashIndexRangeList,
+		UnkHashIndexRange1:   unkHashIndexRangeList0,
+		UnkHashIndexRange2:   unkHashIndexRangeList1,
+		UnkHashIndexRange3:   unkHashIndexRangeList2,
+		PrefabHashIndexRange: prefabHashIndexRangeList,
+		UnkHashIndexRange4:   unkHashIndexRangeList3,
+		UnkHashIndexRange5:   unkHashIndexRangeList4,
 	}, nil
 }

--- a/stingray/level/level.go
+++ b/stingray/level/level.go
@@ -259,21 +259,21 @@ type RawLevel struct {
 }
 
 type Level struct {
-	Name                 stingray.Hash
-	Metadata             map[int][]MetadataEntry
-	Prefabs              []Prefab
-	MaterialOverrides    map[int]map[stingray.ThinHash]stingray.Hash
-	Units                []Unit
-	Speedtrees           []Speedtree
-	Entity               *entity.Entity
-	EmbeddedPrefabs      []EmbeddedPrefab
-	UnitHashIndexRange   []HashIndexRange
-	UnkHashIndexRange1   []HashIndexRange
-	UnkHashIndexRange2   []HashIndexRange
-	UnkHashIndexRange3   []HashIndexRange
-	PrefabHashIndexRange []HashIndexRange
-	UnkHashIndexRange4   []HashIndexRange
-	UnkHashIndexRange5   []HashIndexRange
+	Name                         stingray.Hash
+	Metadata                     map[int][]MetadataEntry
+	Prefabs                      []Prefab
+	MaterialOverrides            map[int]map[stingray.ThinHash]stingray.Hash
+	Units                        []Unit
+	Speedtrees                   []Speedtree
+	Entity                       *entity.Entity
+	EmbeddedPrefabs              []EmbeddedPrefab
+	UnitHashIndexRange           []HashIndexRange
+	UnkHashIndexRange1           []HashIndexRange
+	UnkHashIndexRange2           []HashIndexRange
+	UnkHashIndexRange3           []HashIndexRange
+	PrefabHashIndexRange         []HashIndexRange
+	EmbeddedPrefabHashIndexRange []HashIndexRange
+	UnkHashIndexRange5           []HashIndexRange
 }
 
 func LoadLevel(r io.ReadSeeker, entityVarMapping shading_environment.ShadingEnvironmentEntityToShaderMapping) (*Level, error) {
@@ -527,20 +527,20 @@ func LoadLevel(r io.ReadSeeker, entityVarMapping shading_environment.ShadingEnvi
 	}
 
 	return &Level{
-		Name:                 raw.Name,
-		Metadata:             metadata,
-		Prefabs:              prefabs,
-		MaterialOverrides:    materialOverrides,
-		Units:                units,
-		Speedtrees:           speedtrees,
-		Entity:               embeddedEntity,
-		EmbeddedPrefabs:      embeddedPrefabList,
-		UnitHashIndexRange:   unitHashIndexRangeList,
-		UnkHashIndexRange1:   unkHashIndexRangeList0,
-		UnkHashIndexRange2:   unkHashIndexRangeList1,
-		UnkHashIndexRange3:   unkHashIndexRangeList2,
-		PrefabHashIndexRange: prefabHashIndexRangeList,
-		UnkHashIndexRange4:   unkHashIndexRangeList3,
-		UnkHashIndexRange5:   unkHashIndexRangeList4,
+		Name:                         raw.Name,
+		Metadata:                     metadata,
+		Prefabs:                      prefabs,
+		MaterialOverrides:            materialOverrides,
+		Units:                        units,
+		Speedtrees:                   speedtrees,
+		Entity:                       embeddedEntity,
+		EmbeddedPrefabs:              embeddedPrefabList,
+		UnitHashIndexRange:           unitHashIndexRangeList,
+		UnkHashIndexRange1:           unkHashIndexRangeList0,
+		UnkHashIndexRange2:           unkHashIndexRangeList1,
+		UnkHashIndexRange3:           unkHashIndexRangeList2,
+		PrefabHashIndexRange:         prefabHashIndexRangeList,
+		EmbeddedPrefabHashIndexRange: unkHashIndexRangeList3,
+		UnkHashIndexRange5:           unkHashIndexRangeList4,
 	}, nil
 }

--- a/stingray/prefab/prefab.go
+++ b/stingray/prefab/prefab.go
@@ -21,24 +21,25 @@ type Header struct {
 }
 
 type Unit struct {
-	Unk00 uint64
+	UUID stingray.Hash
 	stingray.Hash
-	Unk01 uint64
+	Name  stingray.Hash
 	Unk02 uint64
 	stingray.Transform
-	UnkFloats mgl32.Vec4
-	Index     uint32
-	UnkData   [20]uint8
+	UnkVec  mgl32.Vec3
+	UnkInt  uint32
+	Index   uint32
+	UnkData [20]uint8
 }
 
-func (o *Unit) Path() stingray.Hash {
-	return o.Hash
+func (u *Unit) Path() stingray.Hash {
+	return u.Hash
 }
 
 type NestedPrefab struct {
-	UnkInt  uint32
-	UnkHash stingray.Hash
-	Path    stingray.Hash
+	UnkInt uint32
+	Name   stingray.Hash
+	Path   stingray.Hash
 	stingray.Transform
 	UnkFloats mgl32.Vec3
 }
@@ -50,13 +51,17 @@ type Prefab struct {
 }
 
 func Load(r io.ReadSeeker) (*Prefab, error) {
+	base, err := r.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return nil, err
+	}
 	var hdr Header
 	if err := binary.Read(r, binary.LittleEndian, &hdr); err != nil {
 		return nil, err
 	}
 	var length uint32
 	if hdr.UnitListOffset != 0 {
-		if _, err := r.Seek(int64(hdr.UnitListOffset), io.SeekStart); err != nil {
+		if _, err := r.Seek(base+int64(hdr.UnitListOffset), io.SeekStart); err != nil {
 			return nil, err
 		}
 		if err := binary.Read(r, binary.LittleEndian, &length); err != nil {
@@ -69,7 +74,7 @@ func Load(r io.ReadSeeker) (*Prefab, error) {
 	}
 	units := make([]Unit, 0, length)
 	for _, offset := range offsets {
-		if _, err := r.Seek(int64(hdr.UnitListOffset+offset), io.SeekStart); err != nil {
+		if _, err := r.Seek(base+int64(hdr.UnitListOffset+offset), io.SeekStart); err != nil {
 			return nil, err
 		}
 		var object Unit
@@ -81,7 +86,7 @@ func Load(r io.ReadSeeker) (*Prefab, error) {
 
 	var prefabsLength uint32
 	if hdr.PrefabListOffset != 0 {
-		if _, err := r.Seek(int64(hdr.PrefabListOffset), io.SeekStart); err != nil {
+		if _, err := r.Seek(base+int64(hdr.PrefabListOffset), io.SeekStart); err != nil {
 			return nil, err
 		}
 		if err := binary.Read(r, binary.LittleEndian, &prefabsLength); err != nil {


### PR DESCRIPTION
Apparently prefabs can be embedded directly in level files, so this change adds support for those prefabs